### PR TITLE
Implement `FHIRPathmixin` to add a basic FHIRPath interface to the `FHIRBaseModel` instances

### DIFF
--- a/fhircraft/fhir/path/__init__.py
+++ b/fhircraft/fhir/path/__init__.py
@@ -1,6 +1,6 @@
 from .parser import FhirPathParser, FhirPathParserError
-from .engine.core import FHIRPathError 
-from .lexer import FhirPathLexerError 
+from .engine.core import FHIRPathError, FHIRPathMixin 
+from .lexer import FhirPathLexerError  
 import traceback
 
 try:

--- a/fhircraft/fhir/path/engine/additional.py
+++ b/fhircraft/fhir/path/engine/additional.py
@@ -4,8 +4,9 @@ FHIR adds (compatible) functionality to the set of common FHIRPath functions. So
 are candidates for elevation to the base version of FHIRPath when the next version is released. 
 """
 
-from fhircraft.fhir.path.engine.core import FHIRPathCollectionItem, FHIRPathFunction, Invocation, Element, Operation, FHIRPath, FHIRPathError
+from fhircraft.fhir.path.engine.core import FHIRPathCollectionItem, FHIRPathFunction, Invocation, Element, FHIRPath, FHIRPathError
 from fhircraft.fhir.path.engine.filtering import Where
+from fhircraft.fhir.path.engine.equality import Equals
 from fhircraft.fhir.resources.datatypes.primitives import Uri, Canonical, Url
 from fhircraft.utils import ensure_list, load_url
 from typing import List, Any, Optional
@@ -23,7 +24,7 @@ class Extension(FHIRPathFunction):
     Note:
         This class is a syntactical shortcut equivalent to:
 
-            Invocation(Element('extension'), Where(Operation(Element('url'), operator.eq, url))) 
+            Invocation(Element('extension'), Where(Equals(Element('url'), url))) 
     """
     def __init__(self, url: str):
         self.url = url
@@ -40,7 +41,7 @@ class Extension(FHIRPathFunction):
             List[FHIRPathCollectionItem]): The indexed collection item.
         """
         collection = ensure_list(collection)
-        return Invocation(Element('extension'), Where(Operation(Element('url'), operator.eq, self.url))).evaluate(collection, create=False) 
+        return Invocation(Element('extension'), Where(Equals(Element('url'), self.url))).evaluate(collection, create=False) 
 
     def __str__(self):
         return f'Extension("{self.url}")'
@@ -192,8 +193,6 @@ class HtmlChecks(FHIRPathFunction):
         Raises:
             FHIRPathError: If the collection is not a single item.
         """
-        from fhircraft.fhir.resources.factory import construct_resource_model
-        from fhircraft.fhir.resources.datatypes import get_complex_FHIR_type
 
         collection = ensure_list(collection)
         

--- a/fhircraft/fhir/path/engine/core.py
+++ b/fhircraft/fhir/path/engine/core.py
@@ -1,6 +1,7 @@
 import logging
 from itertools import *  # noqa
 from fhircraft.utils import ensure_list, contains_list_type, get_fhir_model_from_field
+from fhircraft.fhir.path.utils import import_fhirpath_engine 
 
 import typing
 from typing import List, Optional
@@ -16,6 +17,54 @@ class FHIRPathError(Exception):
     An exception related to FHIRPath specific syntax or runtime criteria.
     """
     pass
+
+class FHIRPathMixin:
+    """ 
+    Mixin class to incorporate a simple FHIRPath interface to the child class.
+    """
+
+    @property
+    def fhirpath(self) -> typing.Callable:
+        """ 
+        Initialized FHIRPath engine instance
+        """
+        return import_fhirpath_engine()
+
+    def get_fhirpath(self, expression:str) -> typing.Union[None,typing.Any, typing.List[typing.Any]]:
+        """
+        Evaluates and retrieves the value(s) of a FHIRPath expression        
+
+        Args:
+            expression (str): FHIRPath expression to evaluate
+
+        Returns:
+            (Union[NoneType,Any, List[Any]): The extracted value(s), or None if no values are found.
+        """
+        # Evaluate the FHIRPath expression
+        collection = self.fhirpath.parse(expression).find(self)
+        # Get the values of the collection items
+        values = [
+            item.value for item in collection 
+                if item.value and not isinstance(item.value, bool)
+        ]
+        if len(values) == 1:
+            return values[0]
+        elif len(values) == 0:
+            return None
+        else:
+            return values    
+
+    def replace_fhirpath(self, expression:str, new_value:typing.Any) -> None:
+        """
+        Evaluates and replaces the value given by a FHIRPath expression        
+
+        Args:
+            expression (str): FHIRPath expression to evaluate
+        """
+        # Evaluate the FHIRPath expression
+        self.fhirpath.parse(expression).update_or_create(self, new_value)
+
+
 
 @dataclass
 class FHIRPathCollectionItem(object):

--- a/fhircraft/fhir/path/engine/core.py
+++ b/fhircraft/fhir/path/engine/core.py
@@ -205,6 +205,7 @@ class FHIRPath(ABC):
             return None
         return values        
 
+
     def find(self, collection: typing.Any) -> List[FHIRPathCollectionItem]:
         """
         Finds and returns a collection of FHIRPathCollectionItem instances from the input collection.
@@ -559,56 +560,3 @@ class Invocation(FHIRPath):
 
     def __hash__(self):
         return hash((self.left, self.right))
-
-
-
-class Operation(FHIRPath):
-    """
-    A class representing an operation in FHIRPath expressions.
-
-    Attributes:
-        left (Union[str, FHIRPath]): The left operand of the operation.
-        op (callable): The operation to be performed.
-        right (Union[str, FHIRPath]): The right operand of the operation.
-    """
-    def __init__(self, left : typing.Union[str,FHIRPath], op : callable,right : typing.Union[str,FHIRPath]):
-        self.left = left
-        self.op = op
-        self.right = right
-        
-    def evaluate(self, collection: List[FHIRPathCollectionItem], create: bool) -> bool:
-        """ 
-        Evaluates the operation on the given collection.
-
-        Args:
-            collection (List[FHIRPathCollectionItem]): The collection of FHIRPathCollectionItem instances to evaluate.
-            create (bool): Flag indicating whether to create new items if they do not exist.
-
-        Returns:
-            bool: The result of the operation evaluation.
-        """
-        collection = ensure_list(collection)
-        return self.op(
-            [
-                item.value if isinstance(item, FHIRPathCollectionItem) else item 
-                    for item in ensure_list(self.left.evaluate(collection, create))
-            ]  if isinstance(self.left, FHIRPath) else ensure_list(self.left), 
-            [ 
-                item.value if isinstance(item, FHIRPathCollectionItem) else item  
-                    for item in ensure_list(self.right.evaluate(collection, create))
-            ] if isinstance(self.right, FHIRPath) else ensure_list(self.right)
-        )
-
-    def __str__(self):
-        return f'{self.left}{self.op}{self.right}'
-
-    def __repr__(self):
-        return f'Operation({self.left.__repr__()},{self.op.__repr__()},{self.right.__repr__()})'
-
-    def __eq__(self, other):
-        return isinstance(other, Operation) and self.left == other.left and self.right == other.right and self.op == other.op
-
-    def __hash__(self):
-        return hash((self.left, self.op, self.right))
-        
-    

--- a/fhircraft/fhir/path/utils.py
+++ b/fhircraft/fhir/path/utils.py
@@ -53,3 +53,8 @@ def join_fhirpath(*segments: str) -> str:
 
 def _underline_error_in_fhir_path(fhir_path, error, error_position):
     return f'{fhir_path[:error_position+len(str(error))+15]}...\n{" "*error_position}{"—"*len(str(error))}'
+    
+
+def import_fhirpath_engine():
+    from fhircraft.fhir.path import fhirpath
+    return fhirpath

--- a/fhircraft/fhir/resources/base.py
+++ b/fhircraft/fhir/resources/base.py
@@ -1,10 +1,11 @@
 from pydantic import BaseModel , ValidationError
 from fhircraft.utils import get_all_models_from_field
+from fhircraft.fhir.path import FHIRPathMixin
 from typing import ClassVar
 from copy import copy
 import inspect 
 
-class FHIRBaseModel(BaseModel):
+class FHIRBaseModel(BaseModel, FHIRPathMixin):
     
     def model_dump(self, *args, **kwargs):
         kwargs.update({'by_alias': True, 'exclude_none': True})

--- a/test/test_fhir_path_engine_core.py
+++ b/test/test_fhir_path_engine_core.py
@@ -246,6 +246,14 @@ def test_fhirpath_find(path_string, data_object, expected_value):
         assert value == expected
 
         
+@pytest.mark.parametrize("path_string, data_object, expected_value", fhirpath_find_test_cases)
+def test_fhirpath_mixin_get_fhirpath(path_string, data_object, expected_value):
+    expected_values = ensure_list(expected_value)
+    found_values = ensure_list(data_object.get_fhirpath(path_string))
+    assert len(found_values) == len(expected_values)
+    for value, expected in zip(found_values, expected_values):
+        assert value == expected
+
 
 
 fhirpath_update_test_cases = (
@@ -262,4 +270,10 @@ fhirpath_update_test_cases = (
 def test_fhirpath_update_existing(path_string, update_value, getattr_fcn):
     _observation = observation.model_copy(deep=True)
     parse(path_string).update_or_create(_observation, update_value)
+    assert getattr_fcn(_observation) == update_value
+
+@pytest.mark.parametrize("path_string, update_value, getattr_fcn", fhirpath_update_test_cases)
+def test_fhirpath_mixin_replace_fhirpath(path_string, update_value, getattr_fcn):
+    _observation = observation.model_copy(deep=True)
+    _observation.replace_fhirpath(path_string, update_value)
     assert getattr_fcn(_observation) == update_value

--- a/test/test_fhir_path_engine_existence.py
+++ b/test/test_fhir_path_engine_existence.py
@@ -1,5 +1,6 @@
 from fhircraft.fhir.path.engine.core import *
 from fhircraft.fhir.path.engine.existence import *
+from fhircraft.fhir.path.engine.comparison import *
 import operator 
 
 import pytest 
@@ -36,13 +37,13 @@ def test_exists_returns_true_for_non_empty_collection():
     assert result is True
 
 def test_exists_applies_criteria_correctly_and_returns_true_if_filtered_collection_has_elements():
-    criteria = Where(Operation(This(), operator.gt,1))
+    criteria = Where(GreaterThan(This(), 1))
     collection = [FHIRPathCollectionItem(value=1), FHIRPathCollectionItem(value=2)]
     result = Exists(criteria).evaluate(collection)
     assert result is True
 
 def test_exists_applies_criteria_correctly_and_returns_false_if_filtered_collection_is_empty():
-    criteria = Where(Operation(This(), operator.gt,9999))
+    criteria = Where(GreaterThan(This(), 9999))
     collection = [FHIRPathCollectionItem(value=1), FHIRPathCollectionItem(value=2)]
     result = Exists(criteria).evaluate(collection)
     assert result is False
@@ -57,13 +58,13 @@ def test_all_returns_true_for_empty_collection():
     assert result is True
     
 def test_all_returns_true_for_criteria_applying_to_all():
-    criteria = Operation(This(), operator.gt,0)
+    criteria = GreaterThan(This(), 0)
     collection = [FHIRPathCollectionItem(value=1), FHIRPathCollectionItem(value=2)]
     result = All(criteria).evaluate(collection)
     assert result is True
     
 def test_all_returns_false_for_criteria_not_applying_to_all():
-    criteria = Operation(This(), operator.gt,0)
+    criteria = GreaterThan(This(), 0)
     collection = [FHIRPathCollectionItem(value=1), FHIRPathCollectionItem(value=2)]
     result = All(criteria).evaluate(collection)
     assert result is True

--- a/test/test_fhir_path_engine_filtering.py
+++ b/test/test_fhir_path_engine_filtering.py
@@ -1,9 +1,7 @@
 from fhircraft.fhir.path.engine.core import *
+from fhircraft.fhir.path.engine.comparison import *
 from fhircraft.fhir.path.engine.filtering import *
-import operator 
 from collections import namedtuple
-import pytest 
-from unittest import TestCase
 
 
 #-------------
@@ -12,12 +10,12 @@ from unittest import TestCase
 
 def test_where_returns_empty_for_empty_collection():
     collection = []
-    result = Where(Operation(This(), operator.lt, 3)).evaluate(collection)
+    result = Where(LessThan(This(), 3)).evaluate(collection)
     assert result == []
 
 def test_where_returns_valid_items_in_collection_where_true():
     collection = [FHIRPathCollectionItem(value=4), FHIRPathCollectionItem(value=1)]
-    result = Where(Operation(This(), operator.lt, 3)).evaluate(collection)
+    result = Where(LessThan(This(), 3)).evaluate(collection)
     assert result == [collection[1]]
 
 


### PR DESCRIPTION
- Implement `FHIRPathmixin` to add a basic FHIRPath interface to the `FHIRBaseModel` instances
- Remove unused prototype classes in `fhir.path` module