### PR TITLE
Quality of life improvements

### DIFF
--- a/fhircraft/fhir/path/__init__.py
+++ b/fhircraft/fhir/path/__init__.py
@@ -2,6 +2,10 @@ from .parser import FhirPathParser, FhirPathParserError
 from .engine.core import FHIRPathError, FHIRPathMixin 
 from .lexer import FhirPathLexerError  
 import traceback
+import warnings 
+
+class FhirPathWwarning(Warning):
+    pass
 
 try:
     fhirpath = FhirPathParser()

--- a/fhircraft/fhir/resources/factory.py
+++ b/fhircraft/fhir/resources/factory.py
@@ -461,13 +461,13 @@ class ResourceFactory:
         return fields, validators, properties
         
 
-    def construct_resource_model(self, canonical_url: str=None, structure_definition: dict=None, base_model: type=FHIRBaseModel) -> FHIRBaseModel:
+    def construct_resource_model(self, canonical_url: str=None, structure_definition: Union[str,dict]=None, base_model: type=FHIRBaseModel) -> FHIRBaseModel:
         """
         Constructs a Pydantic model based on the provided FHIR structure definition.
 
         Args:
             canonical_url (dict): The FHIR resource's or profile's canonical URL from which to download the StructureDefinition.
-            structure_definition (dict): The FHIR StructureDefinition to build the model from.
+            structure_definition (Union[str,dict]): The FHIR StructureDefinition to build the model from specified as a filename or as a dictionary.
 
         Returns:
             model (BaseModel): The constructed Pydantic model representing the FHIR resource.
@@ -476,6 +476,10 @@ class ResourceFactory:
         if canonical_url in self.construction_cache:
             return self.construction_cache[canonical_url]
         # Download the FHIR structure definition if the canonical URL has been specified        
+        if isinstance(structure_definition, str):
+            with open(structure_definition) as file:
+                import json 
+                structure_definition = json.load(file)
         if not structure_definition and canonical_url:
             structure_definition = self.download_structure_definition(canonical_url)
         # Check that the snapshot is available in the FHIR structure definition

--- a/fhircraft/fhir/resources/validators.py
+++ b/fhircraft/fhir/resources/validators.py
@@ -26,7 +26,7 @@ def _validate_FHIR_element_constraint(value:Any, expression:str, human:str, key:
         AssertionError: If the validation fails and severity is not 'warning'.
         Warning: If the validation fails and severity is 'warning'.
     ''' 
-    from fhircraft.fhir.path import fhirpath, FhirPathLexerError, FhirPathParserError
+    from fhircraft.fhir.path import fhirpath, FhirPathLexerError, FhirPathParserError, FhirPathWwarning
     from fhircraft.fhir.path.engine.core import FHIRPathCollectionItem
     if value is None:
         return value
@@ -37,7 +37,7 @@ def _validate_FHIR_element_constraint(value:Any, expression:str, human:str, key:
                 valid = True
             error_message =  f'{human}. [{key}] -> "{expression}"'
             if severity == 'warning' and not valid:
-                warnings.warn(error_message)
+                warnings.warn(error_message, FhirPathWwarning)
             else:
                 assert valid, error_message
         except (ValueError, FhirPathLexerError, FhirPathParserError, AttributeError, NotImplementedError) as e:


### PR DESCRIPTION
This pull request improves the flexibility and clarity of FHIR resource validation and model construction in the codebase. The main changes introduce support for loading FHIR StructureDefinitions from files, provide a custom warning type for FHIRPath validation, and ensure warnings are raised with this new type.

**FHIR resource model construction improvements:**

* Updated `construct_resource_model` in `factory.py` to accept a file path (string) or a dictionary for the `structure_definition` parameter, allowing models to be built from local files as well as dictionaries.
* Added logic to load a JSON StructureDefinition from a file if a string path is provided.

**FHIRPath validation enhancements:**

* Introduced a new custom warning class, `FhirPathWwarning`, in `fhircraft/fhir/path/__init__.py` to distinguish FHIRPath-related warnings.
* Modified `_validate_FHIR_element_constraint` in `validators.py` to import and use `FhirPathWwarning` when raising warnings for constraint validation failures with severity "warning". [[1]](diffhunk://#diff-05621490a7f0cef15b96a9129d4a0b8bda6409b35101c5a1019400b64706875eL29-R29) [[2]](diffhunk://#diff-05621490a7f0cef15b96a9129d4a0b8bda6409b35101c5a1019400b64706875eL40-R40)