### PR TITLE
Implement missing FHIRPath math functions

### DIFF
--- a/fhircraft/fhir/path/engine/math.py
+++ b/fhircraft/fhir/path/engine/math.py
@@ -1,9 +1,14 @@
 """The tree navigation module contains the object representations of the math category FHIRPath operators/functions."""
 
+from math import ceil, exp, floor, log, sqrt
+from typing import Callable
+
 from fhircraft.fhir.path.engine.core import (
     FHIRPath,
     FHIRPathCollection,
     FHIRPathCollectionItem,
+    FHIRPathFunction,
+    Literal,
 )
 from fhircraft.fhir.path.engine.literals import Quantity
 from fhircraft.fhir.path.exceptions import FHIRPathRuntimeError
@@ -88,7 +93,7 @@ class Addition(FHIRMathOperator):
             raise FHIRPathRuntimeError(
                 f"FHIRPath operator {self.__str__()} cannot add {type(left_value).__name__} and {type(right_value).__name__}."
             )
-    
+
     def __str__(self):
         return f"{self.left} + {self.right}"
 
@@ -141,6 +146,7 @@ class Subtraction(FHIRMathOperator):
     def __str__(self):
         return f"{self.left} - {self.right}"
 
+
 class Multiplication(FHIRMathOperator):
     """
     A representation of the FHIRPath [`*`](https://hl7.org/fhirpath/N1/#and) operator.
@@ -186,6 +192,7 @@ class Multiplication(FHIRMathOperator):
 
     def __str__(self):
         return f"{self.left} * {self.right}"
+
 
 class Division(FHIRMathOperator):
     """
@@ -236,6 +243,7 @@ class Division(FHIRMathOperator):
     def __str__(self):
         return f"{self.left} / {self.right}"
 
+
 class Div(FHIRMathOperator):
     """
     A representation of the FHIRPath [`div`](https://hl7.org/fhirpath/N1/#and) operator.
@@ -281,6 +289,7 @@ class Div(FHIRMathOperator):
     def __str__(self):
         return f"{self.left} div {self.right}"
 
+
 class Mod(FHIRMathOperator):
     """
     A representation of the FHIRPath [`mod`](https://hl7.org/fhirpath/N1/#and) operator.
@@ -321,3 +330,149 @@ class Mod(FHIRMathOperator):
 
     def __str__(self):
         return f"{self.left} mod {self.right}"
+
+
+class FHIRPathMathFunction(FHIRPathFunction):
+    """
+    Abstract class definition for the category of math FHIRPath functions.
+    """
+
+    math_operation: Callable
+
+    def evaluate(
+        self, collection: FHIRPathCollection, create=False
+    ) -> FHIRPathCollection:
+        """
+        Computes the computed value based on its argument (supported for Integer, Decimal and Quantity values).
+
+        Args:
+            collection (FHIRPathCollection): The input collection.
+
+        Returns:
+            FHIRPathCollection: The output collection.
+
+        Raises:
+            FHIRPathRuntimeError: For non-singleton collections.
+        """
+        if len(collection) == 0:
+            return []
+        elif len(collection) > 1:
+            raise FHIRPathRuntimeError("Input collection must be a singleton.")
+        value = collection[0].value
+        if isinstance(value, (int, float)):
+            value = self.math_operation(value)
+        elif isinstance(value, (Quantity)):
+            value = Quantity(self.math_operation(value.value), value.unit)
+        else:
+            raise FHIRPathRuntimeError(
+                f"FHIRPath function {self.__class__.__name__}() cannot compute abs for {type(value).__name__}."
+            )
+        return [FHIRPathCollectionItem.wrap(value)]
+
+
+class Abs(FHIRPathMathFunction):
+    """
+    A representation of the FHIRPath [`abs`](https://hl7.org/fhirpath/N1/#abs-integer-decimal-quantity) function.
+    """
+
+    math_operation = abs
+
+
+class Ceiling(FHIRPathMathFunction):
+    """
+    A representation of the FHIRPath [`ceiling`](https://hl7.org/fhirpath/N1/#ceiling-integer) function.
+    """
+
+    math_operation = ceil
+
+
+class Exp(FHIRPathMathFunction):
+    """
+    A representation of the FHIRPath [`exp`](https://hl7.org/fhirpath/N1/#exp-decimal) function.
+    """
+
+    math_operation = exp
+
+
+class Floor(FHIRPathMathFunction):
+    """
+    A representation of the FHIRPath [`floor`](https://hl7.org/fhirpath/N1/#floor-integer) function.
+    """
+
+    math_operation = floor
+
+
+class Ln(FHIRPathMathFunction):
+    """
+    A representation of the FHIRPath [`ln`](https://hl7.org/fhirpath/N1/#ln-decimal) function.
+    """
+
+    math_operation = log
+
+
+class Log(FHIRPathMathFunction):
+    """
+    A representation of the FHIRPath [`log`](https://hl7.org/fhirpath/N1/#log-decimal) function.
+
+    Attributes:
+        base (int | Literal): The base of the logarithm. Must be an integer greater than 1.
+    """
+
+    def __init__(self, base: int | Literal):
+        self.base = base if not isinstance(base, Literal) else base.value
+        if not isinstance(self.base, int) or self.base <= 1:
+            raise FHIRPathRuntimeError(
+                "The base argument of the log function must be an integer greater than 1."
+            )
+        self.math_operation = lambda x: log(x, self.base)
+
+
+class Power(FHIRPathMathFunction):
+    """
+    A representation of the FHIRPath [`power`](https://hl7.org/fhirpath/N1/#powerexponent-integer-decimal-integer-decimal) function.
+
+    Attributes:
+        exponent (int | float | Literal): The exponent to which the input value is raised..
+    """
+
+    def __init__(self, exponent: int | float | Literal):
+        self.exponent = (
+            exponent if not isinstance(exponent, Literal) else exponent.value
+        )
+        if not isinstance(self.exponent, (int, float)):
+            raise FHIRPathRuntimeError(
+                "The exponent argument of the power function must be a number."
+            )
+        self.math_operation = lambda x: pow(x, self.exponent)
+
+
+class Round(FHIRPathMathFunction):
+    """
+    A representation of the FHIRPath [`round`](https://hl7.org/fhirpath/N1/#roundprecision-integer-decimal) function.
+    """
+
+    def __init__(self, precision: int | Literal):
+        self.precision = (
+            precision if not isinstance(precision, Literal) else precision.value
+        )
+        if not isinstance(self.precision, int) or self.precision < 0:
+            raise FHIRPathRuntimeError(
+                "The precision argument of the round function must be a non-negative integer."
+            )
+        self.math_operation = lambda x: round(x, self.precision)
+
+
+class Sqrt(FHIRPathMathFunction):
+    """
+    A representation of the FHIRPath [`sqrt`](https://hl7.org/fhirpath/N1/#sqrt-decimal) function.
+    """
+
+    math_operation = sqrt
+
+
+class Truncate(FHIRPathMathFunction):
+    """
+    A representation of the FHIRPath [`truncate`](https://hl7.org/fhirpath/N1/#truncate-integer) function.
+    """
+
+    math_operation = int

--- a/fhircraft/fhir/path/parser.py
+++ b/fhircraft/fhir/path/parser.py
@@ -1,6 +1,7 @@
 import logging
 import os.path
 from typing import Any
+
 import ply.yacc
 
 import fhircraft.fhir.path.engine.additional as additional
@@ -457,25 +458,25 @@ class FhirPathParser:
         # Math
         # -------------------------------------------------------------------------------
         elif check(p, "abs", nargs=0):
-            raise NotImplementedError()
+            p[0] = math.Abs()
         elif check(p, "ceiling", nargs=0):
-            raise NotImplementedError()
+            p[0] = math.Ceiling()
         elif check(p, "exp", nargs=0):
-            raise NotImplementedError()
+            p[0] = math.Exp()
         elif check(p, "floor", nargs=0):
-            raise NotImplementedError()
+            p[0] = math.Floor()
         elif check(p, "ln", nargs=0):
-            raise NotImplementedError()
+            p[0] = math.Ln()
         elif check(p, "log", nargs=1):
-            raise NotImplementedError()
+            p[0] = math.Log(*p[3])
         elif check(p, "power", nargs=1):
-            raise NotImplementedError()
+            p[0] = math.Power(*p[3])
         elif check(p, "round", nargs=1):
-            raise NotImplementedError()
+            p[0] = math.Round(*p[3])
         elif check(p, "sqrt", nargs=0):
-            raise NotImplementedError()
+            p[0] = math.Sqrt()
         elif check(p, "truncate", nargs=0):
-            raise NotImplementedError()
+            p[0] = math.Truncate()
         # -------------------------------------------------------------------------------
         # Tree navigation
         # -------------------------------------------------------------------------------
@@ -551,7 +552,7 @@ class FhirPathParser:
 
     def p_fhirpath_boolean(self, p):
         "boolean : BOOLEAN"
-        p[0] = True if p[1]=="true" else False
+        p[0] = True if p[1] == "true" else False
 
     def p_fhirpath_datetime(self, p):
         "datetime : DATETIME"
@@ -593,4 +594,5 @@ class IteratorToTokenStream:
         try:
             return next(self.iterator)
         except StopIteration:
+            return None
             return None

--- a/test/test_fhir_path_engine_math.py
+++ b/test/test_fhir_path_engine_math.py
@@ -20,7 +20,7 @@ addition_cases = (
 
 
 @pytest.mark.parametrize("left, right, expected", addition_cases)
-def test_addition_returns_correct_logic_boolean(left, right, expected):
+def test_addition_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Addition(
@@ -29,9 +29,11 @@ def test_addition_returns_correct_logic_boolean(left, right, expected):
     ).evaluate(collection)
     assert result == [FHIRPathCollectionItem(value=expected)]
 
+
 def test_addition_string_representation():
     expression = Addition(Element("left"), Element("right"))
     assert str(expression) == "left + right"
+
 
 # -------------
 # Subtraction
@@ -45,7 +47,7 @@ subtraction_cases = (
 
 
 @pytest.mark.parametrize("left, right, expected", subtraction_cases)
-def test_subtraction_returns_correct_logic_boolean(left, right, expected):
+def test_subtraction_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Subtraction(
@@ -54,9 +56,11 @@ def test_subtraction_returns_correct_logic_boolean(left, right, expected):
     ).evaluate(collection)
     assert result == [FHIRPathCollectionItem(value=expected)]
 
+
 def test_subtraction_string_representation():
     expression = Subtraction(Element("left"), Element("right"))
     assert str(expression) == "left - right"
+
 
 # -------------
 # Multiplication
@@ -71,7 +75,7 @@ multiplication_cases = (
 
 
 @pytest.mark.parametrize("left, right, expected", multiplication_cases)
-def test_multiplication_returns_correct_logic_boolean(left, right, expected):
+def test_multiplication_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Multiplication(
@@ -81,9 +85,11 @@ def test_multiplication_returns_correct_logic_boolean(left, right, expected):
     result = result[0].value if len(result) == 1 else result
     assert result == expected
 
+
 def test_multiplication_string_representation():
     expression = Multiplication(Element("left"), Element("right"))
     assert str(expression) == "left * right"
+
 
 # -------------
 # Division
@@ -99,7 +105,7 @@ division_cases = (
 
 
 @pytest.mark.parametrize("left, right, expected", division_cases)
-def test_division_returns_correct_logic_boolean(left, right, expected):
+def test_division_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Division(
@@ -109,9 +115,11 @@ def test_division_returns_correct_logic_boolean(left, right, expected):
     result = result[0].value if len(result) == 1 else result
     assert result == expected
 
+
 def test_division_string_representation():
     expression = Division(Element("left"), Element("right"))
     assert str(expression) == "left / right"
+
 
 # -------------
 # Div
@@ -127,7 +135,7 @@ div_cases = (
 
 
 @pytest.mark.parametrize("left, right, expected", div_cases)
-def test_div_returns_correct_logic_boolean(left, right, expected):
+def test_div_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Div(
@@ -137,9 +145,11 @@ def test_div_returns_correct_logic_boolean(left, right, expected):
     result = result[0].value if len(result) == 1 else result
     assert result == expected
 
+
 def test_div_string_representation():
     expression = Div(Element("left"), Element("right"))
     assert str(expression) == "left div right"
+
 
 # -------------
 # Mod
@@ -152,7 +162,7 @@ mod_cases = (
 
 
 @pytest.mark.parametrize("left, right, expected", mod_cases)
-def test_mod_returns_correct_logic_boolean(left, right, expected):
+def test_mod_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Mod(
@@ -161,6 +171,321 @@ def test_mod_returns_correct_logic_boolean(left, right, expected):
     ).evaluate(collection)
     assert round(result[0].value, 4) == round(expected, 4)
 
+
 def test_mod_string_representation():
     expression = Mod(Element("left"), Element("right"))
     assert str(expression) == "left mod right"
+
+
+# -------------
+# Abs
+# -------------
+
+abs_cases = (
+    (5, 5),
+    (5.5, 5.5),
+    (Quantity(5, "mg"), Quantity(5, "mg")),
+    (Quantity(5.5, "mg"), Quantity(5.5, "mg")),
+    (-5, 5),
+    (-5.5, 5.5),
+    (Quantity(-5, "mg"), Quantity(5, "mg")),
+    (Quantity(-5.5, "mg"), Quantity(5.5, "mg")),
+)
+
+
+@pytest.mark.parametrize("value, expected", abs_cases)
+def test_abs_returns_correct_value(value, expected):
+    resource = namedtuple("Resource", ["value"])(value=value)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Invocation(Element("value"), Abs()).evaluate(collection)
+    assert result[0].value == expected
+
+
+def test_abs_string_representation():
+    expression = Invocation(Element("value"), Abs())
+    assert str(expression) == "value.abs()"
+
+
+# -------------
+# Ceiling
+# -------------
+
+ceiling_cases = (
+    (5, 5),
+    (5.5, 6),
+    (Quantity(5, "mg"), Quantity(5, "mg")),
+    (Quantity(5.5, "mg"), Quantity(6, "mg")),
+    (-5, -5),
+    (-5.5, -5),
+    (Quantity(-5, "mg"), Quantity(-5, "mg")),
+    (Quantity(-5.5, "mg"), Quantity(-5, "mg")),
+)
+
+
+@pytest.mark.parametrize("value, expected", ceiling_cases)
+def test_ceiling_returns_correct_value(value, expected):
+    resource = namedtuple("Resource", ["value"])(value=value)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Invocation(Element("value"), Ceiling()).evaluate(collection)
+    assert result[0].value == expected
+
+
+def test_ceiling_string_representation():
+    expression = Invocation(Element("value"), Ceiling())
+    assert str(expression) == "value.ceiling()"
+
+
+# -------------
+# Exp
+# -------------
+
+exp_cases = (
+    (5, 148.41316),
+    (5.5, 244.69193),
+    (Quantity(5, "mg"), Quantity(148.41316, "mg")),
+    (Quantity(5.5, "mg"), Quantity(244.69193, "mg")),
+    (-5, 0.00673795),
+    (-5.5, 0.00408677),
+    (Quantity(-5, "mg"), Quantity(0.00673795, "mg")),
+    (Quantity(-5.5, "mg"), Quantity(0.00408677, "mg")),
+)
+
+
+@pytest.mark.parametrize("value, expected", exp_cases)
+def test_exp_returns_correct_value(value, expected):
+    resource = namedtuple("Resource", ["value"])(value=value)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Invocation(Element("value"), Exp()).evaluate(collection)
+    if isinstance(expected, Quantity):
+        assert result[0].value.value == pytest.approx(expected.value, rel=1e-5)
+        assert result[0].value.unit == expected.unit
+    else:
+        assert result[0].value == pytest.approx(expected, rel=1e-5)
+
+
+def test_exp_string_representation():
+    expression = Invocation(Element("value"), Exp())
+    assert str(expression) == "value.exp()"
+
+
+# -------------
+# Floor
+# -------------
+
+floor_cases = (
+    (5, 5),
+    (5.5, 5),
+    (Quantity(5, "mg"), Quantity(5, "mg")),
+    (Quantity(5.5, "mg"), Quantity(5, "mg")),
+    (-5, -5),
+    (-5.5, -6),
+    (Quantity(-5, "mg"), Quantity(-5, "mg")),
+    (Quantity(-5.5, "mg"), Quantity(-6, "mg")),
+)
+
+
+@pytest.mark.parametrize("value, expected", floor_cases)
+def test_floor_returns_correct_value(value, expected):
+    resource = namedtuple("Resource", ["value"])(value=value)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Invocation(Element("value"), Floor()).evaluate(collection)
+    if isinstance(expected, Quantity):
+        assert result[0].value.value == pytest.approx(expected.value, rel=1e-5)
+        assert result[0].value.unit == expected.unit
+    else:
+        assert result[0].value == pytest.approx(expected, rel=1e-5)
+
+
+def test_floor_string_representation():
+    expression = Invocation(Element("value"), Floor())
+    assert str(expression) == "value.floor()"
+
+
+# -------------
+# Ln
+# -------------
+
+ln_cases = (
+    (5, 1.60943791),
+    (5.5, 1.70474809),
+    (Quantity(5, "mg"), Quantity(1.60943791, "mg")),
+    (Quantity(5.5, "mg"), Quantity(1.70474809, "mg")),
+)
+
+
+@pytest.mark.parametrize("value, expected", ln_cases)
+def test_ln_returns_correct_value(value, expected):
+    resource = namedtuple("Resource", ["value"])(value=value)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Invocation(Element("value"), Ln()).evaluate(collection)
+    if isinstance(expected, Quantity):
+        assert result[0].value.value == pytest.approx(expected.value, rel=1e-5)
+        assert result[0].value.unit == expected.unit
+    else:
+        assert result[0].value == pytest.approx(expected, rel=1e-5)
+
+
+def test_ln_string_representation():
+    expression = Invocation(Element("value"), Ln())
+    assert str(expression) == "value.ln()"
+
+
+# -------------
+# Log
+# -------------
+
+log_cases = (
+    (5, 0.698970004),
+    (5.5, 0.740362689),
+    (Quantity(5, "mg"), Quantity(0.698970004, "mg")),
+    (Quantity(5.5, "mg"), Quantity(0.740362689, "mg")),
+)
+
+
+@pytest.mark.parametrize("value, expected", log_cases)
+def test_log_returns_correct_value(value, expected):
+    resource = namedtuple("Resource", ["value"])(value=value)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Invocation(Element("value"), Log(10)).evaluate(collection)
+    if isinstance(expected, Quantity):
+        assert result[0].value.value == pytest.approx(expected.value, rel=1e-5)
+        assert result[0].value.unit == expected.unit
+    else:
+        assert result[0].value == pytest.approx(expected, rel=1e-5)
+
+
+def test_log_string_representation():
+    expression = Invocation(Element("value"), Log(10))
+    assert str(expression) == "value.log(10)"
+
+
+# -------------
+# Power
+# -------------
+
+power_cases = (
+    (5, 25),
+    (5.5, 30.25),
+    (Quantity(5, "mg"), Quantity(25, "mg")),
+    (Quantity(5.5, "mg"), Quantity(30.25, "mg")),
+    (-5, 25),
+    (-5.5, 30.25),
+    (Quantity(-5, "mg"), Quantity(25, "mg")),
+    (Quantity(-5.5, "mg"), Quantity(30.25, "mg")),
+)
+
+
+@pytest.mark.parametrize("value, expected", power_cases)
+def test_power_returns_correct_value(value, expected):
+    resource = namedtuple("Resource", ["value"])(value=value)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Invocation(Element("value"), Power(2)).evaluate(collection)
+    if isinstance(expected, Quantity):
+        assert result[0].value.value == pytest.approx(expected.value, rel=1e-5)
+        assert result[0].value.unit == expected.unit
+    else:
+        assert result[0].value == pytest.approx(expected, rel=1e-5)
+
+
+def test_power_string_representation():
+    expression = Invocation(Element("value"), Power(2))
+    assert str(expression) == "value.power(2)"
+
+
+# -------------
+# Round
+# -------------
+
+round_cases = (
+    (5, 5.0),
+    (5.05, 5.0),
+    (5.15, 5.2),
+    (Quantity(5, "mg"), Quantity(5.0, "mg")),
+    (Quantity(5.05, "mg"), Quantity(5.0, "mg")),
+    (Quantity(5.15, "mg"), Quantity(5.2, "mg")),
+    (-5, -5.0),
+    (-5.05, -5.0),
+    (-5.15, -5.2),
+    (Quantity(-5, "mg"), Quantity(-5.0, "mg")),
+    (Quantity(-5.05, "mg"), Quantity(-5.0, "mg")),
+    (Quantity(-5.15, "mg"), Quantity(-5.2, "mg")),
+)
+
+
+@pytest.mark.parametrize("value, expected", round_cases)
+def test_round_returns_correct_value(value, expected):
+    resource = namedtuple("Resource", ["value"])(value=value)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Invocation(Element("value"), Round(1)).evaluate(collection)
+    if isinstance(expected, Quantity):
+        assert result[0].value.value == pytest.approx(expected.value, rel=1e-5)
+        assert result[0].value.unit == expected.unit
+    else:
+        assert result[0].value == pytest.approx(expected, rel=1e-5)
+
+
+def test_round_string_representation():
+    expression = Invocation(Element("value"), Round(1))
+    assert str(expression) == "value.round(1)"
+
+
+# -------------
+# Sqrt
+# -------------
+
+sqrt_cases = (
+    (5, 2.236067977),
+    (5.5, 2.345207879),
+    (Quantity(5, "mg"), Quantity(2.236067977, "mg")),
+    (Quantity(5.5, "mg"), Quantity(2.345207879, "mg")),
+)
+
+
+@pytest.mark.parametrize("value, expected", sqrt_cases)
+def test_sqrt_returns_correct_value(value, expected):
+    resource = namedtuple("Resource", ["value"])(value=value)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Invocation(Element("value"), Sqrt()).evaluate(collection)
+    if isinstance(expected, Quantity):
+        assert result[0].value.value == pytest.approx(expected.value, rel=1e-5)
+        assert result[0].value.unit == expected.unit
+    else:
+        assert result[0].value == pytest.approx(expected, rel=1e-5)
+
+
+def test_sqrt_string_representation():
+    expression = Invocation(Element("value"), Sqrt())
+    assert str(expression) == "value.sqrt()"
+
+
+# -------------
+# Truncate
+# -------------
+
+truncate_cases = (
+    (5, 5),
+    (5.05, 5),
+    (Quantity(5, "mg"), Quantity(5, "mg")),
+    (Quantity(5.05, "mg"), Quantity(5, "mg")),
+    (-5, -5),
+    (-5.05, -5),
+    (Quantity(-5, "mg"), Quantity(-5, "mg")),
+    (Quantity(-5.05, "mg"), Quantity(-5, "mg")),
+)
+
+
+@pytest.mark.parametrize("value, expected", truncate_cases)
+def test_truncate_returns_correct_value(value, expected):
+    resource = namedtuple("Resource", ["value"])(value=value)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Invocation(Element("value"), Truncate()).evaluate(collection)
+    if isinstance(expected, Quantity):
+        assert result[0].value.value == pytest.approx(expected.value, rel=1e-5)
+        assert result[0].value.unit == expected.unit
+    else:
+        assert result[0].value == pytest.approx(expected, rel=1e-5)
+
+
+def test_truncate_string_representation():
+    expression = Invocation(Element("value"), Truncate())
+    assert str(expression) == "value.truncate()"

--- a/test/test_fhir_path_parser.py
+++ b/test/test_fhir_path_parser.py
@@ -246,6 +246,19 @@ parser_test_cases = (
     ("parent.is('String')", Invocation(Element("parent"), LegacyIs(Literal("String")))),
     ("parent.as('String')", Invocation(Element("parent"), LegacyAs(Literal("String")))),
     # ----------------------------------
+    # Math functions
+    # ----------------------------------
+    ("parent.abs()", Invocation(Element("parent"), Abs())),
+    ("parent.ceiling()", Invocation(Element("parent"), Ceiling())),
+    ("parent.floor()", Invocation(Element("parent"), Floor())),
+    ("parent.log(10)", Invocation(Element("parent"), Log(Literal(10)))),
+    ("parent.sqrt()", Invocation(Element("parent"), Sqrt())),
+    ("parent.exp()", Invocation(Element("parent"), Exp())),
+    ("parent.ln()", Invocation(Element("parent"), Ln())),
+    ("parent.power(2)", Invocation(Element("parent"), Power(Literal(2)))),
+    ("parent.round(2)", Invocation(Element("parent"), Round(Literal(2)))),
+    ("parent.truncate()", Invocation(Element("parent"), Truncate())),
+    # ----------------------------------
     # Utility functions
     # ----------------------------------
     (


### PR DESCRIPTION
This pull request adds full support for FHIRPath math functions to the codebase, implementing their logic and integrating them into the parser. 

Closes #42.

### Math Function Implementation

* Added a new abstract class `FHIRPathMathFunction` and concrete implementations for FHIRPath math functions: `Abs`, `Ceiling`, `Exp`, `Floor`, `Ln`, `Log`, `Power`, `Round`, `Sqrt`, and `Truncate` in `fhircraft/fhir/path/engine/math.py`. These classes encapsulate the computation logic for each function, handling input validation and error cases. [[1]](diffhunk://#diff-52573adec85f560b693a5826abd9e04d6bf3f27ce86f1d2169db09ca80e4f9e6R3-R11) [[2]](diffhunk://#diff-52573adec85f560b693a5826abd9e04d6bf3f27ce86f1d2169db09ca80e4f9e6R333-R478)

### Parser Integration

* Updated `fhircraft/fhir/path/parser.py` so that calls to math functions (`abs`, `ceiling`, `exp`, `floor`, `ln`, `log`, `power`, `round`, `sqrt`, `truncate`) are now properly parsed and mapped to their corresponding implementations, replacing previous `NotImplementedError` stubs.