### PR TITLE
Avoid setting subclass properties on base classes during resource construction 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .ideas/
+.vscode/launch.json

--- a/fhircraft/fhir/resources/factory.py
+++ b/fhircraft/fhir/resources/factory.py
@@ -927,8 +927,6 @@ class ResourceFactory:
                         element, field_type
                     )
                 )
-                for attribute, property_getter in subfield_properties.items():
-                    setattr(field_type, attribute, property(property_getter))
                 if (
                     "extension" in element.children
                     and element.children["extension"].slices
@@ -975,11 +973,12 @@ class ResourceFactory:
                     field_subfields["extension"] = self._construct_Pydantic_field(
                         extension_type, extension_min_card, extension_max_card
                     )
-                field_type = create_model(
+                field_type = self._create_model_with_properties(
                     backbone_model_name,
-                    **field_subfields,
-                    __base__=(field_type,),  # type: ignore
-                    __validators__=subfield_validators,
+                    fields=field_subfields,
+                    base=(field_type,), 
+                    validators=subfield_validators,
+                    properties=subfield_properties,
                 )
             # Handle Python reserved keywords for field names
             safe_field_name, validation_alias = self._handle_python_reserved_keyword(


### PR DESCRIPTION
This pull request refactors the way Pydantic models are created for FHIR backbone elements in `fhircraft/fhir/resources/factory.py`. The main improvement is replacing the direct use of `create_model` with the helper method, `_create_model_with_properties`, to instead of settings resource properties on the base class from which to inherit, leading to bugs downstream. 

* Fixes #8 