### PR TITLE
Ensure correct interpretation of  FHIR cardinality and requiredness 

### DIFF
--- a/fhircraft/fhir/path/engine/core.py
+++ b/fhircraft/fhir/path/engine/core.py
@@ -682,40 +682,43 @@ class Element(FHIRPath):
             else:
                 current_values[index] = value
 
-    def evaluate(
-        self, collection: FHIRPathCollection, create=False
-    ) -> FHIRPathCollection:
+    def _get_collection_by_label(self, collection: FHIRPathCollection, label: str, create: bool) -> FHIRPathCollection:
         element_collection = []
         for item in collection:
             if item.value is None:
                 continue
             if isinstance(item.value, dict):
-                element_value = item.value.get(self.label, None)
+                element_value = item.value.get(label, None)
             else:
-                element_value = getattr(item.value, self.label, None)
+                element_value = getattr(item.value, label, None)
             if not element_value and not isinstance(element_value, bool) and create:
                 element_value = self.create_element(item.value)
                 if isinstance(item.value, dict):
-                    item.value[self.label] = element_value
+                    item.value[label] = element_value
                 else:
-                    setattr(item.value, self.label, element_value)
+                    setattr(item.value, label, element_value)
 
             for index, value in enumerate(ensure_list(element_value)):
                 if create or value is not None:
                     element = FHIRPathCollectionItem(
                         value,
-                        path=Element(self.label),
+                        path=Element(label),
                         parent=item,
                     )
                     element.setter = partial(
                         self.setter,
                         item=item,
                         index=index,
-                        label=self.label,
+                        label=label,
                         is_list_type=element.is_list_type,
                     )
                     element_collection.append(element)
         return element_collection
+    
+    def evaluate(
+        self, collection: FHIRPathCollection, create=False
+    ) -> FHIRPathCollection:
+        return self._get_collection_by_label(collection, self.label, create) or self._get_collection_by_label(collection, f'{self.label}_ext', create)
 
     def __str__(self):
         return self.label

--- a/fhircraft/fhir/path/engine/navigation.py
+++ b/fhircraft/fhir/path/engine/navigation.py
@@ -8,7 +8,6 @@ from fhircraft.fhir.path.engine.core import (
     FHIRPathFunction,
 )
 from fhircraft.fhir.path.engine.filtering import Repeat
-from fhircraft.utils import ensure_list
 
 
 class Children(FHIRPathFunction):
@@ -28,7 +27,6 @@ class Children(FHIRPathFunction):
         Returns:
             FHIRPathCollection: The output collection.
         """
-        collection = ensure_list(collection)
         children_collection = []
         for item in collection:
             if isinstance(item.value, BaseModel):

--- a/fhircraft/fhir/resources/base.py
+++ b/fhircraft/fhir/resources/base.py
@@ -162,7 +162,7 @@ class FHIRBaseModel(BaseModel, FHIRPathMixin):
     
     def __repr__(self) -> str:
         repr_args = []
-        for fieldname in self.model_fields_set or self.__class__model_fields:
+        for fieldname in self.model_fields_set or self.__class__.model_fields:
             value = getattr(self, fieldname)
             repr_args.append(f'{fieldname}={value}')
         return f"{self.__class__.__name__}({', '.join(repr_args)})"

--- a/fhircraft/fhir/resources/datatypes/R4/complex_types.py
+++ b/fhircraft/fhir/resources/datatypes/R4/complex_types.py
@@ -117,7 +117,7 @@ class xhtml(Element):
 
     value: String = Field(
         description="Actual xhtml",
-        default=...,
+        default=None,
     )
     value_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for value extensions",
@@ -458,7 +458,7 @@ class Annotation(Element):
     )
     text: Markdown = Field(
         description="The annotation  - text content (as markdown)",
-        default=...,
+        default=None,
     )
     text_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for text extensions",
@@ -988,7 +988,7 @@ class Contributor(Element):
 
     type: Code = Field(
         description="author | editor | reviewer | endorser",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -997,7 +997,7 @@ class Contributor(Element):
     )
     name: String = Field(
         description="Who contributed the content",
-        default=...,
+        default=None,
     )
     name_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for name extensions",
@@ -1178,7 +1178,7 @@ class DataRequirement(Element):
 
     type: Code = Field(
         description="The type of the required data",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -1749,7 +1749,7 @@ class ElementDefinition(BackboneElement):
 
     path: String = Field(
         description="Path of the element in the hierarchy of elements",
-        default=...,
+        default=None,
     )
     path_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for path extensions",
@@ -3255,7 +3255,7 @@ class Expression(Element):
     )
     language: Code = Field(
         description="text/cql | text/fhirpath | application/x-fhir-query | etc.",
-        default=...,
+        default=None,
     )
     language_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for language extensions",
@@ -3348,7 +3348,7 @@ class Extension(Element):
 
     url: String = Field(
         description="identifies the meaning of the extension",
-        default=...,
+        default=None,
     )
     url_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for url extensions",
@@ -3889,7 +3889,7 @@ class MarketingStatus(BackboneElement):
 
     country: "CodeableConcept" = Field(
         description="The country in which the marketing authorisation has been granted shall be specified It should be specified using the ISO 3166 \u2011 1 alpha-2 code elements",
-        default=...,
+        default=None,
     )
     jurisdiction: typing.Optional["CodeableConcept"] = Field(
         description="Where a Medicines Regulatory Agency has granted a marketing authorisation for which specific provisions within a jurisdiction apply, the jurisdiction can be specified using an appropriate controlled terminology The controlled term and the controlled term identifier shall be specified",
@@ -3897,11 +3897,11 @@ class MarketingStatus(BackboneElement):
     )
     status: "CodeableConcept" = Field(
         description="This attribute provides information on the status of the marketing of the medicinal product See ISO/TS 20443 for more information and examples",
-        default=...,
+        default=None,
     )
     dateRange: "Period" = Field(
         description="The date when the Medicinal Product is placed on the market by the Marketing Authorisation Holder (or where applicable, the manufacturer/distributor) in a country and/or jurisdiction shall be provided A complete date consisting of day, month and year shall be specified using the ISO 8601 date format NOTE \u201cPlaced on the market\u201d refers to the release of the Medicinal Product into the distribution chain",
-        default=...,
+        default=None,
     )
     restoreDate: typing.Optional[DateTime] = Field(
         description="The date when the Medicinal Product is placed on the market by the Marketing Authorisation Holder (or where applicable, the manufacturer/distributor) in a country and/or jurisdiction shall be provided A complete date consisting of day, month and year shall be specified using the ISO 8601 date format NOTE \u201cPlaced on the market\u201d refers to the release of the Medicinal Product into the distribution chain",
@@ -4142,7 +4142,7 @@ class Narrative(Element):
 
     status: Code = Field(
         description="generated | extensions | additional | empty",
-        default=...,
+        default=None,
     )
     status_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for status extensions",
@@ -4151,7 +4151,7 @@ class Narrative(Element):
     )
     div: str = Field(
         description="Limited xhtml content",
-        default=...,
+        default=None,
     )
 
     @field_validator(
@@ -4231,7 +4231,7 @@ class ParameterDefinition(Element):
     )
     use: Code = Field(
         description="in | out",
-        default=...,
+        default=None,
     )
     use_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for use extensions",
@@ -4267,7 +4267,7 @@ class ParameterDefinition(Element):
     )
     type: Code = Field(
         description="What type of value",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -4652,11 +4652,11 @@ class ProductShelfLife(BackboneElement):
     )
     type: "CodeableConcept" = Field(
         description="This describes the shelf life, taking into account various scenarios such as shelf life of the packaged Medicinal Product itself, shelf life after transformation where necessary and shelf life after the first opening of a bottle, etc. The shelf life type shall be specified using an appropriate controlled vocabulary The controlled term and the controlled term identifier shall be specified",
-        default=...,
+        default=None,
     )
     period: "Quantity" = Field(
         description="The shelf life time period can be specified using a numerical value for the period of time and its unit of time measurement The unit of measurement shall be specified in accordance with ISO 11240 and the resulting terminology The symbol and the symbol identifier shall be used",
-        default=...,
+        default=None,
     )
     specialPrecautionsForStorage: typing.Optional[typing.List["CodeableConcept"]] = (
         Field(
@@ -5056,7 +5056,7 @@ class RelatedArtifact(Element):
 
     type: Code = Field(
         description="documentation | justification | citation | predecessor | successor | derived-from | depends-on | composed-of",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -5174,11 +5174,11 @@ class SampledData(Element):
 
     origin: "Quantity" = Field(
         description="Zero value and units",
-        default=...,
+        default=None,
     )
     period: Decimal = Field(
         description="Number of milliseconds between samples",
-        default=...,
+        default=None,
     )
     period_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for period extensions",
@@ -5214,7 +5214,7 @@ class SampledData(Element):
     )
     dimensions: PositiveInt = Field(
         description="Number of sample points at each time point",
-        default=...,
+        default=None,
     )
     dimensions_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for dimensions extensions",
@@ -5292,11 +5292,11 @@ class Signature(Element):
 
     type: typing.List["Coding"] = Field(
         description="Indication of the reason the entity signed the object(s)",
-        default=...,
+        default=None,
     )
     when: Instant = Field(
         description="When the signature was created",
-        default=...,
+        default=None,
     )
     when_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for when extensions",
@@ -5305,7 +5305,7 @@ class Signature(Element):
     )
     who: "Reference" = Field(
         description="Who signed",
-        default=...,
+        default=None,
     )
     onBehalfOf: typing.Optional["Reference"] = Field(
         description="The party represented",
@@ -5683,7 +5683,7 @@ class TriggerDefinition(Element):
 
     type: Code = Field(
         description="named-event | periodic | data-changed | data-added | data-modified | data-removed | data-accessed | data-access-ended",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -5824,23 +5824,23 @@ class UsageContext(Element):
 
     code: "Coding" = Field(
         description="Type of context being specified",
-        default=...,
+        default=None,
     )
     valueCodeableConcept: "CodeableConcept" = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
     valueQuantity: "Quantity" = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
     valueRange: "Range" = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
     valueReference: "Reference" = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
 
     @field_validator(*("code", "extension"), mode="after", check_fields=None)

--- a/fhircraft/fhir/resources/datatypes/R4B/complex_types.py
+++ b/fhircraft/fhir/resources/datatypes/R4B/complex_types.py
@@ -117,7 +117,7 @@ class xhtml(Element):
 
     value: String = Field(
         description="Actual xhtml",
-        default=...,
+        default=None,
     )
     value_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for value extensions",
@@ -335,7 +335,7 @@ class Annotation(Element):
     )
     text: Markdown = Field(
         description="The annotation  - text content (as markdown)",
-        default=...,
+        default=None,
     )
     text_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for text extensions",
@@ -918,7 +918,7 @@ class Contributor(Element):
 
     type: Code = Field(
         description="author | editor | reviewer | endorser",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -927,7 +927,7 @@ class Contributor(Element):
     )
     name: String = Field(
         description="Who contributed the content",
-        default=...,
+        default=None,
     )
     name_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for name extensions",
@@ -985,7 +985,7 @@ class DataRequirement(Element):
 
     type: Code = Field(
         description="The type of the required data",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -1310,7 +1310,7 @@ class ElementDefinition(BackboneElement):
 
     path: String = Field(
         description="Path of the element in the hierarchy of elements",
-        default=...,
+        default=None,
     )
     path_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for path extensions",
@@ -2831,7 +2831,7 @@ class Expression(Element):
     )
     language: Code = Field(
         description="text/cql | text/fhirpath | application/x-fhir-query | text/cql-identifier | text/cql-expression | etc.",
-        default=...,
+        default=None,
     )
     language_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for language extensions",
@@ -2924,7 +2924,7 @@ class Extension(Element):
 
     url: String = Field(
         description="identifies the meaning of the extension",
-        default=...,
+        default=None,
     )
     url_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for url extensions",
@@ -3478,7 +3478,7 @@ class MarketingStatus(BackboneElement):
     )
     status: "CodeableConcept" = Field(
         description="This attribute provides information on the status of the marketing of the medicinal product See ISO/TS 20443 for more information and examples",
-        default=...,
+        default=None,
     )
     dateRange: typing.Optional["Period"] = Field(
         description="The date when the Medicinal Product is placed on the market by the Marketing Authorisation Holder (or where applicable, the manufacturer/distributor) in a country and/or jurisdiction shall be provided A complete date consisting of day, month and year shall be specified using the ISO 8601 date format NOTE \u201cPlaced on the market\u201d refers to the release of the Medicinal Product into the distribution chain",
@@ -3723,7 +3723,7 @@ class Narrative(Element):
 
     status: Code = Field(
         description="generated | extensions | additional | empty",
-        default=...,
+        default=None,
     )
     status_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for status extensions",
@@ -3732,7 +3732,7 @@ class Narrative(Element):
     )
     div: str = Field(
         description="Limited xhtml content",
-        default=...,
+        default=None,
     )
 
     @field_validator(
@@ -3812,7 +3812,7 @@ class ParameterDefinition(Element):
     )
     use: Code = Field(
         description="in | out",
-        default=...,
+        default=None,
     )
     use_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for use extensions",
@@ -3848,7 +3848,7 @@ class ParameterDefinition(Element):
     )
     type: Code = Field(
         description="What type of value",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -4233,11 +4233,11 @@ class ProductShelfLife(BackboneElement):
     )
     type: "CodeableConcept" = Field(
         description="This describes the shelf life, taking into account various scenarios such as shelf life of the packaged Medicinal Product itself, shelf life after transformation where necessary and shelf life after the first opening of a bottle, etc. The shelf life type shall be specified using an appropriate controlled vocabulary The controlled term and the controlled term identifier shall be specified",
-        default=...,
+        default=None,
     )
     period: "Quantity" = Field(
         description="The shelf life time period can be specified using a numerical value for the period of time and its unit of time measurement The unit of measurement shall be specified in accordance with ISO 11240 and the resulting terminology The symbol and the symbol identifier shall be used",
-        default=...,
+        default=None,
     )
     specialPrecautionsForStorage: typing.Optional[typing.List["CodeableConcept"]] = (
         Field(
@@ -4977,7 +4977,7 @@ class RelatedArtifact(Element):
 
     type: Code = Field(
         description="documentation | justification | citation | predecessor | successor | derived-from | depends-on | composed-of",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -5095,11 +5095,11 @@ class SampledData(Element):
 
     origin: "Quantity" = Field(
         description="Zero value and units",
-        default=...,
+        default=None,
     )
     period: Decimal = Field(
         description="Number of milliseconds between samples",
-        default=...,
+        default=None,
     )
     period_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for period extensions",
@@ -5135,7 +5135,7 @@ class SampledData(Element):
     )
     dimensions: PositiveInt = Field(
         description="Number of sample points at each time point",
-        default=...,
+        default=None,
     )
     dimensions_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for dimensions extensions",
@@ -5213,11 +5213,11 @@ class Signature(Element):
 
     type: typing.List["Coding"] = Field(
         description="Indication of the reason the entity signed the object(s)",
-        default=...,
+        default=None,
     )
     when: Instant = Field(
         description="When the signature was created",
-        default=...,
+        default=None,
     )
     when_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for when extensions",
@@ -5226,7 +5226,7 @@ class Signature(Element):
     )
     who: "Reference" = Field(
         description="Who signed",
-        default=...,
+        default=None,
     )
     onBehalfOf: typing.Optional["Reference"] = Field(
         description="The party represented",
@@ -5503,7 +5503,7 @@ class TriggerDefinition(Element):
 
     type: Code = Field(
         description="named-event | periodic | data-changed | data-added | data-modified | data-removed | data-accessed | data-access-ended",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -5644,23 +5644,23 @@ class UsageContext(Element):
 
     code: "Coding" = Field(
         description="Type of context being specified",
-        default=...,
+        default=None,
     )
     valueCodeableConcept: "CodeableConcept" = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
     valueQuantity: "Quantity" = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
     valueRange: "Range" = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
     valueReference: "Reference" = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
 
     @field_validator(*("code", "extension"), mode="after", check_fields=None)

--- a/fhircraft/fhir/resources/datatypes/R5/complex_types.py
+++ b/fhircraft/fhir/resources/datatypes/R5/complex_types.py
@@ -133,7 +133,7 @@ class xhtml(Element):
 
     value: String = Field(
         description="Actual xhtml",
-        default=...,
+        default=None,
     )
     value_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for value extensions",
@@ -342,7 +342,7 @@ class Annotation(Element):
     )
     text: Markdown = Field(
         description="The annotation  - text content (as markdown)",
-        default=...,
+        default=None,
     )
     text_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for text extensions",
@@ -1062,7 +1062,7 @@ class Contributor(Element):
 
     type: Code = Field(
         description="author | editor | reviewer | endorser",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -1071,7 +1071,7 @@ class Contributor(Element):
     )
     name: String = Field(
         description="Who contributed the content",
-        default=...,
+        default=None,
     )
     name_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for name extensions",
@@ -1127,7 +1127,7 @@ class DataRequirement(Element):
 
     type: Code = Field(
         description="The type of the required data",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -1485,7 +1485,7 @@ class ElementDefinition(BackboneType):
 
     path: String = Field(
         description="Path of the element in the hierarchy of elements",
-        default=...,
+        default=None,
     )
     path_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for path extensions",
@@ -3322,7 +3322,7 @@ class Extension(DataType):
 
     url: String = Field(
         description="identifies the meaning of the extension",
-        default=...,
+        default=None,
     )
     url_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for url extensions",
@@ -3901,7 +3901,7 @@ class MarketingStatus(BackboneType):
     )
     status: CodeableConcept = Field(
         description="This attribute provides information on the status of the marketing of the medicinal product See ISO/TS 20443 for more information and examples",
-        default=...,
+        default=None,
     )
     dateRange: typing.Optional["Period"] = Field(
         description="The date when the Medicinal Product is placed on the market by the Marketing Authorization Holder (or where applicable, the manufacturer/distributor) in a country and/or jurisdiction shall be provided A complete date consisting of day, month and year shall be specified using the ISO 8601 date format NOTE \u201cPlaced on the market\u201d refers to the release of the Medicinal Product into the distribution chain",
@@ -4083,7 +4083,7 @@ class MonetaryComponent(DataType):
 
     type: Code = Field(
         description="base | surcharge | deduction | discount | tax | informational",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -4226,7 +4226,7 @@ class Narrative(DataType):
 
     status: Code = Field(
         description="generated | extensions | additional | empty",
-        default=...,
+        default=None,
     )
     status_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for status extensions",
@@ -4235,7 +4235,7 @@ class Narrative(DataType):
     )
     div: str = Field(
         description="Limited xhtml content",
-        default=...,
+        default=None,
     )
 
     @field_validator(
@@ -4315,7 +4315,7 @@ class ParameterDefinition(DataType):
     )
     use: Code = Field(
         description="in | out",
-        default=...,
+        default=None,
     )
     use_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for use extensions",
@@ -4351,7 +4351,7 @@ class ParameterDefinition(DataType):
     )
     type: Code = Field(
         description="What type of value",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -5221,7 +5221,7 @@ class RelatedArtifact(DataType):
 
     type: Code = Field(
         description="documentation | justification | citation | predecessor | successor | derived-from | depends-on | composed-of | part-of | amends | amended-with | appends | appended-with | cites | cited-by | comments-on | comment-in | contains | contained-in | corrects | correction-in | replaces | replaced-with | retracts | retracted-by | signs | similar-to | supports | supported-with | transforms | transformed-into | transformed-with | documents | specification-of | created-with | cite-as",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -5362,7 +5362,7 @@ class SampledData(DataType):
 
     origin: Quantity = Field(
         description="Zero value and units",
-        default=...,
+        default=None,
     )
     interval: typing.Optional[Decimal] = Field(
         description="Number of intervalUnits between samples",
@@ -5375,7 +5375,7 @@ class SampledData(DataType):
     )
     intervalUnit: Code = Field(
         description="The measurement unit of the interval between samples",
-        default=...,
+        default=None,
     )
     intervalUnit_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for intervalUnit extensions",
@@ -5411,7 +5411,7 @@ class SampledData(DataType):
     )
     dimensions: PositiveInt = Field(
         description="Number of sample points at each time point",
-        default=...,
+        default=None,
     )
     dimensions_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for dimensions extensions",
@@ -5813,7 +5813,7 @@ class TriggerDefinition(DataType):
 
     type: Code = Field(
         description="named-event | periodic | data-changed | data-added | data-modified | data-removed | data-accessed | data-access-ended",
-        default=...,
+        default=None,
     )
     type_ext: typing.Optional["Element"] = Field(
         description="Placeholder element for type extensions",
@@ -5971,23 +5971,23 @@ class UsageContext(DataType):
 
     code: Coding = Field(
         description="Type of context being specified",
-        default=...,
+        default=None,
     )
     valueCodeableConcept: CodeableConcept = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
     valueQuantity: Quantity = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
     valueRange: Range = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
     valueReference: Reference = Field(
         description="Value that defines the context",
-        default=...,
+        default=None,
     )
 
     @field_validator(*("code", "extension"), mode="after", check_fields=None)

--- a/fhircraft/fhir/resources/factory.py
+++ b/fhircraft/fhir/resources/factory.py
@@ -497,14 +497,12 @@ class ResourceFactory:
         if is_list_type:
             actual_field_type = List[actual_field_type]
         
-        # All fields are non-required (Pydantic), since cardinality and requiredness is handled by FHIR validators 
+        # All fields are non-required and non-nullable
         if default is _Unset:
             default = None
         elif is_list_type:
             default = ensure_list(default)
-                
-        if min_card == 0:
-            actual_field_type = Optional[actual_field_type]
+            
         # Construct the Pydantic field
         return (
             actual_field_type,

--- a/fhircraft/fhir/resources/factory.py
+++ b/fhircraft/fhir/resources/factory.py
@@ -493,13 +493,18 @@ class ResourceFactory:
         # Determine whether typing should be a list based on max. cardinality
         is_list_type = max_card is None or max_card > 1
         actual_field_type = field_type
+        # Handle list types
         if is_list_type:
             actual_field_type = List[actual_field_type]
-            default = ensure_list(default) if default is not _Unset else default
-        # Determine whether the field is optional
+        
+        # All fields are non-required (Pydantic), since cardinality and requiredness is handled by FHIR validators 
+        if default is _Unset:
+            default = None
+        elif is_list_type:
+            default = ensure_list(default)
+                
         if min_card == 0:
             actual_field_type = Optional[actual_field_type]
-            default = None
         # Construct the Pydantic field
         return (
             actual_field_type,

--- a/fhircraft/fhir/resources/factory.py
+++ b/fhircraft/fhir/resources/factory.py
@@ -1156,7 +1156,7 @@ class ResourceFactory:
                     self._handle_python_reserved_keyword(f"{name}_ext")
                 )
                 fields[safe_ext_field_name] = self._construct_Pydantic_field(
-                    get_complex_FHIR_type("Extension", self.Config.FHIR_release if self.Config else "4.3.0"),
+                    get_complex_FHIR_type("Element", self.Config.FHIR_release if self.Config else "4.3.0"),
                     min_card=0,
                     max_card=1,
                     alias=f"_{name}",

--- a/test/test_fhir_path_engine_core.py
+++ b/test/test_fhir_path_engine_core.py
@@ -199,6 +199,12 @@ class TestElement(TestCase):
         result = Element("status").evaluate(self.collection, create=False)
         assert result[0].parent == self.collection[0]
 
+def test_children_returns_correct_primitive_extension():
+    ext = dict(extension=[dict(url="http://example.com/ext", value="Extension Value")])
+    resource = dict(fieldA=1, fieldB_ext=ext)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Element('fieldB').evaluate(collection)
+    assert result[0].value == ext
 
 class TestInvocation(TestCase):
 

--- a/test/test_fhir_path_engine_navigation.py
+++ b/test/test_fhir_path_engine_navigation.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 from fhircraft.fhir.path.engine.core import *
 from fhircraft.fhir.path.engine.navigation import *
+from fhircraft.fhir.resources.datatypes.R4.complex_types import Element as El, Extension
 
 # -------------
 # Children
@@ -16,13 +17,27 @@ def test_children_returns_empty_for_empty_collection():
     assert result == []
 
 
-def test_children_returns_correct_elements():
+def test_children_returns_correct_elements_model():
     class Resource(BaseModel):
         fieldA: int
         fieldB: int
         fieldC: int
 
     resource = Resource(fieldA=1, fieldB=2, fieldC=3)
+    collection = [FHIRPathCollectionItem(value=resource)]
+    result = Children().evaluate(collection)
+    assert result[0].value == 1
+    assert result[1].value == 2
+    assert result[2].value == 3
+
+
+def test_children_returns_correct_elements_dict():
+    class Resource(BaseModel):
+        fieldA: int
+        fieldB: int
+        fieldC: int
+
+    resource = Resource(fieldA=1, fieldB=2, fieldC=3).model_dump()
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Children().evaluate(collection)
     assert result[0].value == 1

--- a/test/test_fhir_resources_factory.py
+++ b/test/test_fhir_resources_factory.py
@@ -230,7 +230,7 @@ class TestConstructPydanticField(FactoryTestCase):
             field_type, min_card=1, max_card=1
         )
         assert result[0] == field_type
-        assert result[1].is_required() == True
+        assert result[1].is_required() == False
 
     def test_constructs_optional_field(self):
         field_type = primitives.String
@@ -247,7 +247,7 @@ class TestConstructPydanticField(FactoryTestCase):
             field_type, min_card=1, max_card=99999
         )
         assert result[0] == List[field_type]
-        assert result[1].is_required() == True
+        assert result[1].is_required() == False
 
     def test_constructs_optional_list_field(self):
         field_type = primitives.String
@@ -327,6 +327,7 @@ class TestProcessCardinalityConstraints(FactoryTestCase):
 
     @parameterized.expand(
         [
+            (ElementDefinition.model_construct(min=0, max="0"), 0, 0),
             (ElementDefinition.model_construct(min=0, max="1"), 0, 1),
             (ElementDefinition.model_construct(min=1, max="2"), 1, 2),
             (ElementDefinition.model_construct(min=0, max="*"), 0, 99999),
@@ -670,16 +671,9 @@ class TestPythonKeywordHandlingIntegration(FactoryTestCase):
         # Check that both the main field and extension field were created with safe names
         fields = model.model_fields
 
-        # Should have 'for_' field for the main field
         assert "for_" in fields
+        assert "for_ext" in fields
 
-        # Should have an extension field for the 'for' field (primitive fields get _ext fields)
-        # The extension field name will be based on the original name + '_ext',
-        # then checked for keywords
-        ext_field_candidates = [
-            name for name in fields.keys() if "for" in name and "ext" in name
-        ]
-        assert len(ext_field_candidates) > 0
 
 
 class TestResourceFactoryPackageMethods(TestCase):

--- a/test/test_fhir_resources_factory.py
+++ b/test/test_fhir_resources_factory.py
@@ -232,12 +232,12 @@ class TestConstructPydanticField(FactoryTestCase):
         assert result[0] == field_type
         assert result[1].is_required() == False
 
-    def test_constructs_optional_field(self):
+    def test_constructs_non_optional_field(self):
         field_type = primitives.String
         result = self.factory._construct_Pydantic_field(
             field_type, min_card=0, max_card=1
         )
-        assert result[0] == Optional[field_type]
+        assert result[0] == field_type
         assert result[1].is_required() == False
         assert result[1].default is None
 
@@ -254,7 +254,7 @@ class TestConstructPydanticField(FactoryTestCase):
         result = self.factory._construct_Pydantic_field(
             field_type, min_card=0, max_card=99999
         )
-        assert result[0] == Optional[List[field_type]]
+        assert result[0] == List[field_type]
         assert result[1].is_required() == False
         assert result[1].default is None
 


### PR DESCRIPTION
This PR introduces several improvements and bug fixes to FHIR resource model construction and primitive extension handling:

#### Correct interpretation of cardinality 

Based on the FHIR specification ([reference](https://build.fhir.org/conformance-rules.html#cardinality)):

>Note that when present, elements cannot be empty - they SHALL have a value attribute, child elements, or extensions. The element's value attribute/property can never be empty. Either it is absent, or it is present with at least one character of non-whitespace content. This means that setting an element to a minimum cardinality of 1 does not ensure that data will be present; specific FHIRPath constraints are required to ensure that the required data will be present.

- Prevents required data elements in FHIR resource models by setting `default=None` by default. Fixes #57.
- Prevents nullable data elements in FHIR resource models (by not using the `Optional` annotation when min. cardinality is zero)

Now all Fhircraft model fields are optional, but not nullable, and presence of data elements is delegated to FHIRPath invariants as intended by the specification.


#### Other fixes:

- Ensures primitive extensions are of type `Element` with correct versioning (Fixes #50, reverses a commit in #55)
- Updates FHIRPath element operation to return the primitive extension if primitive value is not set. 
- Includes minor bug fixes.

