### PR TITLE
Fix the FHIRPath `Concatenation` operation to ensure full strings are concatenated

### DIFF
--- a/fhircraft/fhir/path/engine/strings.py
+++ b/fhircraft/fhir/path/engine/strings.py
@@ -602,11 +602,9 @@ class Concatenation(FHIRPath):
             create,
             prevent_all_empty=False,
         )
-        left_value = left_value or [""]
-        right_value = right_value or [""]
-        left = left_value[0]
-        right = right_value[0]
-        return [FHIRPathCollectionItem.wrap(f"{left}{right}")]
+        left_value = left_value or ""
+        right_value = right_value or ""
+        return [FHIRPathCollectionItem.wrap(f"{left_value}{right_value}")]
 
     def __str__(self):
         return f"{self.left} & {self.right}"

--- a/test/test_fhir_path_engine_strings.py
+++ b/test/test_fhir_path_engine_strings.py
@@ -1,9 +1,9 @@
 import pytest
 
 from fhircraft.fhir.path.engine.core import (
-    Literal,
     FHIRPathCollectionItem,
     FHIRPathError,
+    Literal,
 )
 from fhircraft.fhir.path.engine.strings import *
 
@@ -51,9 +51,11 @@ def test_indexOf_returns_zero_if_empty_substring():
     result = IndexOf("").evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=0)]
 
+
 def test_indexOf_string_representation():
     expression = IndexOf("Substring")
     assert str(expression) == "indexOf('Substring')"
+
 
 # -------------
 # Substring
@@ -89,6 +91,7 @@ def test_substring_returns_empty_if_start_out_of_bounds():
     result = Substring(100).evaluate(collection, env)
     assert result == []
 
+
 def test_substring_string_representation():
     expression = Substring(2, 11)
     assert str(expression) == "substring(2, 11)"
@@ -116,9 +119,11 @@ def test_startswith_returns_false_if_not_starts_with_prefix():
     result = StartsWith("yourSub").evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=False)]
 
+
 def test_startswith_string_representation():
     expression = StartsWith("mySub")
     assert str(expression) == "startsWith('mySub')"
+
 
 # -------------
 # EndsWith
@@ -142,9 +147,11 @@ def test_endswith_returns_false_if_not_ends_with_suffix():
     result = EndsWith("Values").evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=False)]
 
+
 def test_endswith_string_representation():
     expression = EndsWith("Value")
     assert str(expression) == "endsWith('Value')"
+
 
 # -------------
 # Contains
@@ -168,9 +175,11 @@ def test_contains_returns_false_if_not_substring_contained():
     result = Contains("Substrings").evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=False)]
 
+
 def test_contains_string_representation():
     expression = Contains("Substring")
     assert str(expression) == "contains('Substring')"
+
 
 # -------------
 # Upper
@@ -188,9 +197,11 @@ def test_upper_returns_uppercase_string():
     result = Upper().evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value="MYSUBSTRINGVALUE")]
 
+
 def test_upper_string_representation():
     expression = Upper()
     assert str(expression) == "upper()"
+
 
 # -------------
 # Lower
@@ -208,9 +219,11 @@ def test_lower_returns_lowercase_string():
     result = Lower().evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value="mysubstringvalue")]
 
+
 def test_lower_string_representation():
     expression = Lower()
     assert str(expression) == "lower()"
+
 
 # -------------
 # Replace
@@ -240,9 +253,11 @@ def test_replace_sorround_all_characters():
     result = Replace("", "X").evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value="XaXbX")]
 
+
 def test_replace_string_representation():
     expression = Replace("my", "your")
     assert str(expression) == "replace('my', 'your')"
+
 
 # ----------------
 # Matches
@@ -266,9 +281,11 @@ def test_matches_returns_false_if_not_match():
     result = Matches(r"^(?:your).*").evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=False)]
 
+
 def test_matches_string_representation():
     expression = Matches(r"^(?:my).*")
     assert str(expression) == "matches('^(?:my).*')"
+
 
 # ----------------
 # ReplaceMatches
@@ -286,9 +303,11 @@ def test_replacematches_pattern():
     result = ReplaceMatches(r"^(?:my)", "your").evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value="yourSubstringValue")]
 
+
 def test_replacematches_string_representation():
     expression = ReplaceMatches(r"^(?:my)", "your")
     assert str(expression) == "replaceMatches('^(?:my)', 'your')"
+
 
 # ----------------
 # Length
@@ -306,9 +325,11 @@ def test_length_returns_correct_length():
     result = Length().evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=16)]
 
+
 def test_length_string_representation():
     expression = Length()
     assert str(expression) == "length()"
+
 
 # ----------------
 # ToChars
@@ -326,9 +347,11 @@ def test_tochars_returns_collection_of_characters():
     result = ToChars().evaluate(collection, env)
     assert [item.value for item in result] == ["A", "B", "C"]
 
+
 def test_tochars_string_representation():
     expression = ToChars()
     assert str(expression) == "toChars()"
+
 
 # ----------------
 # Concatenation
@@ -344,16 +367,19 @@ def test_concatenation_returns_empty_string_if_empty():
 def test_concatenation_returns_concatenated_string():
     collection = []
     result = Concatenation(
-        [FHIRPathCollectionItem(value="A")], [FHIRPathCollectionItem(value="B")]
+        [FHIRPathCollectionItem(value="Abc")], [FHIRPathCollectionItem(value="Bcd")]
     ).evaluate(collection, env)
-    assert result == [FHIRPathCollectionItem(value="AB")]
+    assert result == [FHIRPathCollectionItem(value="AbcBcd")]
 
 
 def test_concatenation_treats_empty_as_empty_string():
     collection = []
-    result = Concatenation([FHIRPathCollectionItem(value="A")], []).evaluate(collection, env)
-    assert result == [FHIRPathCollectionItem(value="A")]
+    result = Concatenation([FHIRPathCollectionItem(value="Abc")], []).evaluate(
+        collection, env
+    )
+    assert result == [FHIRPathCollectionItem(value="Abc")]
+
 
 def test_concatenation_string_representation():
-    expression = Concatenation(Literal("A"), Literal("B"))
-    assert str(expression) == "'A' & 'B'"
+    expression = Concatenation(Literal("Abc"), Literal("Bcd"))
+    assert str(expression) == "'Abc' & 'Bcd'"


### PR DESCRIPTION
This pull request refactors the string concatenation logic in the FHIRPath engine and updates the corresponding tests for clarity and correctness. The main change ensures that concatenation treats string entirely and not just the first character. 

* Closes #89 