### PR TITLE
Fix FHIRPath type handling with `RootElement` support

### DIFF
--- a/fhircraft/fhir/path/engine/types.py
+++ b/fhircraft/fhir/path/engine/types.py
@@ -9,6 +9,7 @@ from fhircraft.fhir.path.engine.core import (
     FHIRPathCollectionItem,
     FHIRPathFunction,
     Literal,
+    RootElement,
     This,
 )
 from fhircraft.fhir.path.exceptions import FHIRPathRuntimeError
@@ -20,9 +21,21 @@ class FHIRTypesOperator(FHIRPath):
     Abstract class definition for the category of types FHIRPath operators.
     """
 
-    def __init__(self, left: FHIRPath | FHIRPathCollection, type_specifier: str):
+    def __init__(
+        self,
+        left: FHIRPath | FHIRPathCollection,
+        type_specifier: str | Literal | RootElement,
+    ):
+        self.type_specifier = (
+            type_specifier.type
+            if isinstance(type_specifier, RootElement)
+            else (
+                type_specifier
+                if isinstance(type_specifier, str)
+                else type_specifier.value
+            )
+        )
         self.left = left
-        self.type_specifier = type_specifier
 
     def _get_singleton_collection_value(
         self, collection: FHIRPathCollection, environment: dict, create: bool = False
@@ -130,9 +143,15 @@ class LegacyIs(FHIRPathFunction):
         type_specifier (str): Type specifier.
     """
 
-    def __init__(self, type_specifier: str | Literal):
+    def __init__(self, type_specifier: str | Literal | RootElement):
         self.type_specifier = (
-            type_specifier if isinstance(type_specifier, str) else type_specifier.value
+            type_specifier.type
+            if isinstance(type_specifier, RootElement)
+            else (
+                type_specifier
+                if isinstance(type_specifier, str)
+                else type_specifier.value
+            )
         )
 
     def evaluate(
@@ -196,11 +215,15 @@ class LegacyAs(FHIRPathFunction):
         type_specifier (str): Type specifier.
     """
 
-    def __init__(self, type_specifier: str | Literal):
+    def __init__(self, type_specifier: str | Literal | RootElement):
         self.type_specifier: str = (
             type_specifier.value
             if isinstance(type_specifier, Literal)
-            else type_specifier
+            else (
+                type_specifier.type
+                if isinstance(type_specifier, RootElement)
+                else type_specifier
+            )
         )
 
     def evaluate(

--- a/fhircraft/fhir/resources/datatypes/utils.py
+++ b/fhircraft/fhir/resources/datatypes/utils.py
@@ -8,6 +8,7 @@ and FHIRPath conversion functions use these utilities.
 
 import importlib
 import re
+import warnings
 from datetime import date, datetime, time
 from typing import TYPE_CHECKING, Any, Type, Union
 
@@ -197,7 +198,9 @@ def is_fhir_resource_type(
 
     try:
         if hasattr(fhir_type, "model_validate"):
-            fhir_type.model_validate(value)  # type: ignore
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                fhir_type.model_validate(value)  # type: ignore
         return True
     except ValidationError as e:
         return False

--- a/test/test_fhir_path_engine_types.py
+++ b/test/test_fhir_path_engine_types.py
@@ -47,6 +47,22 @@ test_cases = (
     ("invalid", "Boolean", False),
     (Date("@2024"), "Date", True),
     (Quantity(12, "g"), "Quantity", True),
+    # Root element type checking
+    (
+        dict(id="123", resourceType="Observation"),
+        RootElement(type="Observation"),
+        True,
+    ),
+    (
+        dict(id="123", resourceType="Patient"),
+        RootElement(type="Patient"),
+        True,
+    ),
+    (
+        dict(id="123", resourceType="Condition"),
+        RootElement(type="Observation"),
+        False,
+    ),
 )
 
 
@@ -59,9 +75,11 @@ def test_is_returns_correct_boolean(left, type_specifier, expected):
     )
     assert result[0].value == expected
 
+
 def test_is_string_representation():
-    expression = Is(Element('field'), 'String')
+    expression = Is(Element("field"), "String")
     assert str(expression) == "field is String"
+
 
 @pytest.mark.parametrize("left, type_specifier, expected", test_cases)
 def test_legacy_is_returns_correct_boolean(left, type_specifier, expected):
@@ -69,9 +87,11 @@ def test_legacy_is_returns_correct_boolean(left, type_specifier, expected):
     result = LegacyIs(type_specifier).evaluate(collection, env)
     assert result[0].value == expected
 
+
 def test_legacy_is_string_representation():
-    expression = LegacyIs('String')
+    expression = LegacyIs("String")
     assert str(expression) == "is(String)"
+
 
 # -------------
 # As
@@ -84,9 +104,11 @@ def test_as_returns_correct_boolean(expected, type_specifier, equal):
     result = As(This(), type_specifier).evaluate(collection, env)
     assert result[0].value == expected if equal else result == []
 
+
 def test_as_string_representation():
-    expression = As(Element('field'), 'String')
+    expression = As(Element("field"), "String")
     assert str(expression) == "field as String"
+
 
 @pytest.mark.parametrize("expected, type_specifier, equal", test_cases)
 def test_legacy_as_returns_correct_boolean(expected, type_specifier, equal):
@@ -94,6 +116,7 @@ def test_legacy_as_returns_correct_boolean(expected, type_specifier, equal):
     result = LegacyAs(type_specifier).evaluate(collection, env)
     assert result[0].value == expected if equal else result == []
 
+
 def test_legacy_as_string_representation():
-    expression = LegacyAs('String')
+    expression = LegacyAs("String")
     assert str(expression) == "as(String)"


### PR DESCRIPTION
This pull request fixes the support for using `RootElement` as a type specifier in FHIRPath type operators and functions, fixing the errors raised by the  type checking capabilities for FHIRPath. 

* Closes #91 

### Changes

* Updated `FHIRTypesOperator` (inherited by `Is` and `As`), `LegacyIs`, and `LegacyAs` classes to accept `RootElement` as a valid type specifier, extracting the type appropriately for type checking. 
* Suppressed warnings during FHIR resource type validation in `is_fhir_resource_type` to avoid noisy warnings.
* Added test cases for type checking with `RootElement` in `test/test_fhir_path_engine_types.py`, ensuring correct behavior for resource type matching.