### PR TITLE
Enhance `hasValue` and `getValue` functions to check for FHIR primitive values 

### DIFF
--- a/fhircraft/fhir/path/engine/additional.py
+++ b/fhircraft/fhir/path/engine/additional.py
@@ -21,8 +21,9 @@ from fhircraft.fhir.path.engine.core import (
 )
 from fhircraft.fhir.path.engine.equality import Equals
 from fhircraft.fhir.path.engine.filtering import Where
-from fhircraft.fhir.path.engine.literals import Quantity
+from fhircraft.fhir.path.engine.literals import Date, DateTime, Quantity, Time
 from fhircraft.utils import ensure_list, load_url
+from fhircraft.fhir.resources.datatypes.utils import is_fhir_primitive, to_date
 
 
 class Extension(FHIRPathFunction):
@@ -136,12 +137,17 @@ class HasValue(FHIRPathFunction):
             collection (FHIRPathCollection): The output collection.
         """
         if len(collection) != 1:
-            has_value = False
+            has_primitive_value = False
         else:
-            # TODO: add check for primitive
-            item = collection[0]
-            has_value = item.value is not None
-        return [FHIRPathCollectionItem.wrap(has_value)]
+            value = collection[0].value
+            if isinstance(value, Date):
+                value = value.to_date()
+            elif isinstance(value, Time):
+                value = value.to_time()
+            elif isinstance(value, DateTime):
+                value = value.to_datetime()
+            has_primitive_value = value is not None and is_fhir_primitive(value)
+        return [FHIRPathCollectionItem.wrap(has_primitive_value)]
 
 
 class GetValue(FHIRPathFunction):
@@ -164,11 +170,20 @@ class GetValue(FHIRPathFunction):
         Returns:
             collection (FHIRPathCollection): The output collection.
         """
-        if not HasValue().evaluate(collection, environment, create=create):
-            return []
         if len(collection) != 1:
             return []
-        return [collection[0]]
+        else:
+            value = collection[0].value
+            if isinstance(value, Date):
+                value = value.to_date()
+            elif isinstance(value, Time):
+                value = value.to_time()
+            elif isinstance(value, DateTime):
+                value = value.to_datetime()
+
+            has_primitive_value = value is not None and is_fhir_primitive(value)
+            print(value, has_primitive_value)
+            return [FHIRPathCollectionItem.wrap(value)] if has_primitive_value else []
 
 
 class Resolve(FHIRPathFunction):

--- a/fhircraft/fhir/path/engine/literals.py
+++ b/fhircraft/fhir/path/engine/literals.py
@@ -117,6 +117,8 @@ class Date(FHIRPathLiteralType):
                 return op(self.to_date(), other.to_date())
             else:
                 return []
+        elif isinstance(other, date):
+            return op(self.to_date(), other)
         else:
             raise TypeError("Comparisons only supported between Date objects")
 
@@ -203,6 +205,8 @@ class Time(FHIRPathLiteralType):
                 return op(self.to_time(), other.to_time())
             else:
                 return []
+        elif isinstance(other, time):
+            return op(self.to_time(), other)
         else:
             raise TypeError("Comparisons only supported between Date objects")
 
@@ -309,6 +313,8 @@ class DateTime(FHIRPathLiteralType):
                 return op(self.to_datetime(), other.to_datetime())
             else:
                 return []
+        elif isinstance(other, datetime):
+            return op(self.to_datetime(), other)
         else:
             raise TypeError("Comparisons only supported between Date objects")
 

--- a/fhircraft/fhir/resources/datatypes/utils.py
+++ b/fhircraft/fhir/resources/datatypes/utils.py
@@ -75,6 +75,20 @@ def get_fhir_resource_type(type_str: str, release="R4B") -> type:
     return resource
 
 
+def is_fhir_primitive(value: Any) -> bool:
+    """Check if a value is a FHIR primitive type."""
+    primitive_types = tuple(
+        getattr(primitives, name)
+        for name in dir(primitives)
+        if not name.startswith("_")
+        and isinstance(getattr(primitives, name), TypeAliasType)
+    )
+    return any(
+        is_fhir_primitive_type(value, ptype, raise_on_error=False)
+        for ptype in primitive_types
+    )
+
+
 # Type checking functions
 def is_fhir_primitive_type(
     value: Any, fhir_type: Type | TypeAliasType | str, raise_on_error: bool = True

--- a/test/test_fhir_path_engine_additional.py
+++ b/test/test_fhir_path_engine_additional.py
@@ -1,7 +1,10 @@
 from collections import namedtuple
 
+import pytest
+
 from fhircraft.fhir.path.engine.additional import *
 from fhircraft.fhir.path.engine.core import *
+from fhircraft.fhir.path.engine.literals import Date, DateTime
 from fhircraft.fhir.resources.datatypes import get_complex_FHIR_type
 
 env = dict()
@@ -40,6 +43,19 @@ def test_extension_selects_correct_extension_by_url():
 # HasValue
 # -------------
 
+has_value_cases = (
+    "ABC",
+    123,
+    1.23,
+    True,
+    False,
+    Date("@2012"),
+    Date("@2012-01"),
+    DateTime("@2012-01-01T10:30"),
+    DateTime("@2012-01-01T10:30:12.312"),
+    "1 year",
+)
+
 
 def test_hasvalue_returns_false_for_empty_collection():
     collection = []
@@ -47,19 +63,32 @@ def test_hasvalue_returns_false_for_empty_collection():
     assert result[0].value == False
 
 
-def test_hasvaslue_returns_true_for_singleton_collection_with_value():
-    collection = [FHIRPathCollectionItem(value=1)]
+@pytest.mark.parametrize("value", has_value_cases)
+def test_hasvalue_returns_true_for_singleton_collection_with_primitive_value(value):
+    collection = [FHIRPathCollectionItem(value=value)]
     result = HasValue().evaluate(collection, env)
     assert result[0].value == True
 
 
-def test_hasvaslue_returns_true_for_singleton_collection_without_value():
+def test_hasvalue_returns_false_for_singleton_collection_without_primitive_value():
+    collection = [
+        FHIRPathCollectionItem(
+            value=get_complex_FHIR_type("Extension")(
+                url="http://domain.org/extension1", valueInteger=1
+            )
+        )
+    ]
+    result = HasValue().evaluate(collection, env)
+    assert result[0].value == False
+
+
+def test_hasvalue_returns_true_for_singleton_collection_without_value():
     collection = [FHIRPathCollectionItem(value=None)]
     result = HasValue().evaluate(collection, env)
     assert result[0].value == False
 
 
-def test_hasvaslue_returns_false_for_collection_with_multiple_items():
+def test_hasvalue_returns_false_for_collection_with_multiple_items():
     collection = [FHIRPathCollectionItem(value=1), FHIRPathCollectionItem(value=2)]
     result = HasValue().evaluate(collection, env)
     assert result[0].value == False
@@ -69,6 +98,19 @@ def test_hasvaslue_returns_false_for_collection_with_multiple_items():
 # GetValue
 # -------------
 
+get_value_cases = (
+    "ABC",
+    123,
+    1.23,
+    True,
+    False,
+    Date("@2012"),
+    Date("@2012-01"),
+    DateTime("@2012-01-01T10:30"),
+    DateTime("@2012-01-01T10:30:12.312"),
+    "1 year",
+)
+
 
 def test_getvalue_returns_empty_for_empty_collection():
     collection = []
@@ -76,10 +118,23 @@ def test_getvalue_returns_empty_for_empty_collection():
     assert result == []
 
 
-def test_getvalue_returns_true_for_singleton_collection_with_value():
-    collection = [FHIRPathCollectionItem(value=1)]
+@pytest.mark.parametrize("value", get_value_cases)
+def test_getvalue_returns_value_for_singleton_collection_with_primitive_value(value):
+    collection = [FHIRPathCollectionItem(value=value)]
     result = GetValue().evaluate(collection, env)
-    assert result[0].value == 1
+    assert result[0].value == value
+
+
+def test_getvalue_returns_empty_for_singleton_collection_without_primitive_value():
+    collection = [
+        FHIRPathCollectionItem(
+            value=get_complex_FHIR_type("Extension")(
+                url="http://domain.org/extension1", valueInteger=1
+            )
+        )
+    ]
+    result = GetValue().evaluate(collection, env)
+    assert result == []
 
 
 def test_getvalue_returns_empty_for_collection_with_multiple_items():

--- a/test/test_fhir_path_engine_comparison.py
+++ b/test/test_fhir_path_engine_comparison.py
@@ -1,137 +1,145 @@
-import pytest 
+import pytest
 from collections import namedtuple
 from fhircraft.fhir.path.engine.literals import Quantity
 from fhircraft.fhir.path.engine.comparison import *
 from fhircraft.fhir.path.engine.additional import GetValue
-from fhircraft.fhir.path.engine.core import Element,  FHIRPathCollectionItem, Invocation
+from fhircraft.fhir.path.engine.core import Element, FHIRPathCollectionItem, Invocation
 
 env = dict()
 
-#-------------
+# -------------
 # GreaterThan
-#-------------
+# -------------
 
 greater_than_cases = (
     (10, 5, True),
     (10, 5.0, True),
-    ('abc', 'ABC', True),
-    (Quantity(12, 'm'), Quantity(4, 'm'), True),
+    ("abc", "ABC", True),
+    (Quantity(12, "m"), Quantity(4, "m"), True),
     # (Quantity(4, 'm'), Quantity(4, 'cm'), True), # Unit conversion not implemented yet
-    ('@2018-03-01', '@2018-01-01', True),
-    ('@2018-03', '@2018-03-01', False),
-    ('@2018-03-01T10:30:00', '@2018-03-01T10:00:00', True),
-    ('@2018-03-01T10', '@2018-03-01T10:30', False),
-    ('@T10:30:00', '@T10:00:00', True),
-    ('@T10', '@T10:30', False),
-    ('@T10:30:00', '@T10:30:00.0', False),
+    ("@2018-03-01", "@2018-01-01", True),
+    ("@2018-03", "@2018-03-01", False),
+    ("@2018-03-01T10:30:00", "@2018-03-01T10:00:00", True),
+    ("@2018-03-01T10", "@2018-03-01T10:30", False),
+    ("@T10:30:00", "@T10:00:00", True),
+    ("@T10", "@T10:30", False),
+    ("@T10:30:00", "@T10:30:00.0", False),
 )
+
 
 @pytest.mark.parametrize("left, right, expected", greater_than_cases)
 def test_greater_than_returns_correct_boolean(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = GreaterThan(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=expected)]
+
 
 def test_greaterthan_string_representation():
     expression = GreaterThan(Element("left"), Element("right"))
     assert str(expression) == "left > right"
 
 
-#-------------
+# -------------
 # LessThan
-#-------------
+# -------------
 
 
 less_than_cases = (
     (10, 5, False),
     (10, 5.0, False),
-    ('abc', 'ABC', False),
-    (Quantity(4, 'm'), Quantity(40, 'm'), True),
+    ("abc", "ABC", False),
+    (Quantity(4, "m"), Quantity(40, "m"), True),
     # (Quantity(4, 'm'), Quantity(4, 'cm'), False), # Unit conversion not implemented yet
-    ('@2018-03-01', '@2018-01-01', False),
-    ('@2018-03-01T10:30:00', '@2018-03-01T10:00:00', False),
-    ('@2018-03-01T10', '@2018-03-01T10:30', True),
-    ('@T10:30:00', '@T10:00:00', False),
-    ('@T10', '@T10:30', True),
+    ("@2018-03-01", "@2018-01-01", False),
+    ("@2018-03-01T10:30:00", "@2018-03-01T10:00:00", False),
+    ("@2018-03-01T10", "@2018-03-01T10:30", True),
+    ("@T10:30:00", "@T10:00:00", False),
+    ("@T10", "@T10:30", True),
 )
+
 
 @pytest.mark.parametrize("left, right, expected", less_than_cases)
 def test_less_than_returns_correct_boolean(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = LessThan(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=expected)]
+
 
 def test_lessthan_string_representation():
     expression = LessThan(Element("left"), Element("right"))
     assert str(expression) == "left < right"
 
 
-#----------------
+# ----------------
 # LessEqualThan
-#----------------
+# ----------------
 
 less_equal_than_cases = (
     (10, 5, False),
     (2.5, 5.0, True),
-    ('abc', 'ABC', False),
-    (Quantity(4, 'm'), Quantity(4, 'm'), True),
-    (Quantity(12, 'm'), Quantity(4, 'm'), False),
+    ("abc", "ABC", False),
+    (Quantity(4, "m"), Quantity(4, "m"), True),
+    (Quantity(12, "m"), Quantity(4, "m"), False),
     # (Quantity(4, 'm'), Quantity(4, 'cm'), False), # Unit conversion not implemented yet
-    ('@2018-03-01', '@2018-01-01', False),
-    ('@2018-03-01T10:30:00', '@2018-03-01T10:00:00', False),
-    ('@2018-03-01T10:30:00', '@2018-03-01T10:30:00.0', True),
-    ('@T10:30:00', '@T10:00:00', False),
-    ('@T10:30:00', '@T10:30:00.0', True),
+    ("@2018-03-01", "@2018-01-01", False),
+    ("@2018-03-01T10:30:00", "@2018-03-01T10:00:00", False),
+    ("@2018-03-01T10:30:00", "@2018-03-01T10:30:00.0", True),
+    ("@T10:30:00", "@T10:00:00", False),
+    ("@T10:30:00", "@T10:30:00.0", True),
 )
+
 
 @pytest.mark.parametrize("left, right, expected", less_equal_than_cases)
 def test_less_equal_than_returns_correct_boolean(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = LessEqualThan(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=expected)]
+
 
 def test_lessequalthan_string_representation():
     expression = LessEqualThan(Element("left"), Element("right"))
     assert str(expression) == "left <= right"
 
 
-#----------------
+# ----------------
 # GreaterEqualThan
-#----------------
+# ----------------
 
 greater_equal_than_cases = (
     (10, 5, True),
     (2.5, 5.0, False),
-    ('abc', 'ABC', True),
-    (Quantity(4, 'm'), Quantity(4, 'm'), True),
-    (Quantity(12, 'm'), Quantity(4, 'm'), True),
+    ("abc", "ABC", True),
+    (Quantity(4, "m"), Quantity(4, "m"), True),
+    (Quantity(12, "m"), Quantity(4, "m"), True),
     # (Quantity(4, 'm'), Quantity(4, 'cm'), False), # Unit conversion not implemented yet
-    ('@2018-03-01', '@2018-01-01', True),
-    ('@2018-03-01T10:30:00', '@2018-03-01T10:00:00', True),
-    ('@T10:30:00', '@T10:00:00', True),
+    ("@2018-03-01", "@2018-01-01", True),
+    ("@2018-03-01T10:30:00", "@2018-03-01T10:00:00", True),
+    ("@T10:30:00", "@T10:00:00", True),
 )
+
 
 @pytest.mark.parametrize("left, right, expected", greater_equal_than_cases)
 def test_greater_equal_than_returns_correct_boolean(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = GreaterEqualThan(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=expected)]
+
 
 def test_greater_equal_than_string_representation():
     expression = GreaterEqualThan(Element("left"), Element("right"))

--- a/test/test_fhir_path_engine_equality.py
+++ b/test/test_fhir_path_engine_equality.py
@@ -43,8 +43,8 @@ def test_equals_returns_correct_boolean(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Equals(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=expected)]
 
@@ -59,8 +59,8 @@ def test_notequals_returns_correct_boolean(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = NotEquals(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     assert result != [FHIRPathCollectionItem(value=expected)]
 
@@ -110,8 +110,8 @@ def test_equivalent_returns_correct_boolean(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Equivalent(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=expected)]
 
@@ -126,8 +126,8 @@ def test_notequivalent_returns_correct_boolean(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = NotEquivalent(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     assert result != [FHIRPathCollectionItem(value=expected)]
 

--- a/test/test_fhir_path_engine_math.py
+++ b/test/test_fhir_path_engine_math.py
@@ -26,8 +26,8 @@ def test_addition_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Addition(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=expected)]
 
@@ -53,8 +53,8 @@ def test_subtraction_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Subtraction(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     assert result == [FHIRPathCollectionItem(value=expected)]
 
@@ -81,8 +81,8 @@ def test_multiplication_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Multiplication(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     result = result[0].value if len(result) == 1 else result
     assert result == expected
@@ -111,8 +111,8 @@ def test_division_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Division(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     result = result[0].value if len(result) == 1 else result
     assert result == expected
@@ -141,8 +141,8 @@ def test_div_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Div(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     result = result[0].value if len(result) == 1 else result
     assert result == expected
@@ -168,8 +168,8 @@ def test_mod_returns_correct_value(left, right, expected):
     resource = namedtuple("Resource", ["left", "right"])(left=left, right=right)
     collection = [FHIRPathCollectionItem(value=resource)]
     result = Mod(
-        Invocation(Element("left"), GetValue()),
-        Invocation(Element("right"), GetValue()),
+        Element("left"),
+        Element("right"),
     ).evaluate(collection, env)
     assert round(result[0].value, 4) == round(expected, 4)
 

--- a/test/test_fhir_path_engine_types.py
+++ b/test/test_fhir_path_engine_types.py
@@ -70,14 +70,12 @@ test_cases = (
 def test_is_returns_correct_boolean(left, type_specifier, expected):
     resource = namedtuple("Resource", ["left"])(left=left)
     collection = [FHIRPathCollectionItem(value=resource)]
-    result = Is(Invocation(Element("left"), GetValue()), type_specifier).evaluate(
-        collection, env
-    )
+    result = Is(Element("left"), type_specifier).evaluate(collection, env)
     assert result[0].value == expected
 
 
 def test_is_returns_empty_for_empty_collection():
-    result = Is(Invocation(Element("left"), GetValue()), "String").evaluate([], env)
+    result = Is(Element("left"), "String").evaluate([], env)
     assert result == []
 
 


### PR DESCRIPTION

This pull request refactors the FHIRPath engine to improve handling of FHIR primitive types, specifically for the `HasValue` and `GetValue` functions, and enhances comparison logic for date, time, and datetime types. It introduces a utility for detecting FHIR primitives, updates the relevant engine functions to use this utility, and simplifies test cases by removing redundant invocations. The changes also improve test coverage and clarity for primitive value handling.

* Fixes #43 and #104

### FHIR primitive type handling

* Added the `is_fhir_primitive` utility function in `fhircraft.fhir.resources.datatypes.utils` to reliably check if a value is a FHIR primitive type.
* Updated `HasValue` and `GetValue` in `fhircraft.fhir.path.engine.additional.py` to use the new primitive detection logic, ensuring correct behavior for FHIR primitives and complex types. [[1]](diffhunk://#diff-21ac513aa9cdbbf30080e98167cfa66be605f284530684b5310bfdb081600ebfL139-R150) [[2]](diffhunk://#diff-21ac513aa9cdbbf30080e98167cfa66be605f284530684b5310bfdb081600ebfL167-R186)
* Extended imports in `fhircraft.fhir.path.engine.additional.py` to include `Date`, `DateTime`, and `Time` for proper primitive type handling.

### Comparison logic improvements

* Enhanced comparison methods for `Date`, `Time`, and `DateTime` types in `fhircraft.fhir.path.engine.literals.py` to allow direct comparison with native Python `date`, `time`, and `datetime` objects. [[1]](diffhunk://#diff-b893df909b0668d1530e834cef52a1eb1195e072f7c997037c05abd856e72131R120-R121) [[2]](diffhunk://#diff-b893df909b0668d1530e834cef52a1eb1195e072f7c997037c05abd856e72131R208-R209) [[3]](diffhunk://#diff-b893df909b0668d1530e834cef52a1eb1195e072f7c997037c05abd856e72131R316-R317)

### Test suite enhancements

* Refactored and expanded tests for `HasValue` and `GetValue` in `test/test_fhir_path_engine_additional.py`, including parameterized cases for various primitive types and complex types, and improved assertions for expected behaviors. [[1]](diffhunk://#diff-6411252595beccfeb5db920e138a07481df7e5fb1b30d4042c090b7188d2f03dR46-R91) [[2]](diffhunk://#diff-6411252595beccfeb5db920e138a07481df7e5fb1b30d4042c090b7188d2f03dR101-R137)
* Updated equality, comparison, and math tests to remove unnecessary `Invocation(GetValue())` wrappers, simplifying the test logic and improving readability. [[1]](diffhunk://#diff-b03f95bd69602e04eb2d9c3762a6c2c144209cbd30f4917169bc960af8a571efL46-R47) [[2]](diffhunk://#diff-b03f95bd69602e04eb2d9c3762a6c2c144209cbd30f4917169bc960af8a571efL62-R63) [[3]](diffhunk://#diff-b03f95bd69602e04eb2d9c3762a6c2c144209cbd30f4917169bc960af8a571efL113-R114) [[4]](diffhunk://#diff-b03f95bd69602e04eb2d9c3762a6c2c144209cbd30f4917169bc960af8a571efL129-R130) [[5]](diffhunk://#diff-e11e31a63963b32e5fdeeb4e8c9e9c49cb1f8e6ee3e03fb9d0cffca72d2371faL29-R30) [[6]](diffhunk://#diff-e11e31a63963b32e5fdeeb4e8c9e9c49cb1f8e6ee3e03fb9d0cffca72d2371faL56-R57) [[7]](diffhunk://#diff-e11e31a63963b32e5fdeeb4e8c9e9c49cb1f8e6ee3e03fb9d0cffca72d2371faL84-R85) [[8]](diffhunk://#diff-e11e31a63963b32e5fdeeb4e8c9e9c49cb1f8e6ee3e03fb9d0cffca72d2371faL114-R115) [[9]](diffhunk://#diff-4cb4a985f887076081a248981615e51dcad50cb551f74957d4b53d86acec81c9L17-R40) [[10]](diffhunk://#diff-4cb4a985f887076081a248981615e51dcad50cb551f74957d4b53d86acec81c9L52-R75) [[11]](diffhunk://#diff-4cb4a985f887076081a248981615e51dcad50cb551f74957d4b53d86acec81c9L84-R110) [[12]](diffhunk://#diff-4cb4a985f887076081a248981615e51dcad50cb551f74957d4b53d86acec81c9L117-R143)