### PR TITLE
Change `ValidationError` to `TypeError` in `validate_contained_resource`

### DIFF
--- a/fhircraft/fhir/resources/validators.py
+++ b/fhircraft/fhir/resources/validators.py
@@ -5,7 +5,7 @@ import warnings
 # Standard modules
 from typing import TYPE_CHECKING, Any, List, TypeVar, Union
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from fhircraft.fhir.resources.base import FHIRBaseModel, FHIRSliceModel
@@ -282,7 +282,7 @@ def validate_contained_resource(
             )
             validated_resources.append(resourceModel.model_validate(resource))
         else:
-            raise ValidationError(
+            raise TypeError(
                 "Contained resource must be a FHIRBaseModel or a dict, and must have a 'resourceType' property."
             )
 


### PR DESCRIPTION
### FIxes

* Fixes the error 
   ```  
   TypeError: ValidationError.__new__() missing 1 required positional argument: 'line_errors'
   ```
   when trying to raise the `ValidationError` in `validate_contained_resource`.