### PR TITLE
Fix contained resource validation logic

### DIFF
--- a/fhircraft/fhir/resources/validators.py
+++ b/fhircraft/fhir/resources/validators.py
@@ -276,7 +276,7 @@ def validate_contained_resource(
     for i, resource in enumerate(resources):
         if isinstance(resource, FHIRBaseModel):
             validated_resources.append(resource)
-        if isinstance(resource, dict) and "resourceType" in resource:
+        elif isinstance(resource, dict) and "resourceType" in resource:
             resourceModel = get_fhir_resource_type(
                 resource["resourceType"], release=release
             )


### PR DESCRIPTION
This pull request makes a minor improvement to the resource validation logic in `fhircraft/fhir/resources/validators.py`. The change ensures that only one branch of the conditional executes for each resource, preventing potential double-processing.

* In the `validate_contained_resource` function, changed the second `if` to `elif` to avoid processing the same resource in both branches.