### PR TITLE
Implement unit conversion and handling for FHIRPath `Quantity` and add UCUM definitions support

### DIFF
--- a/fhircraft/fhir/path/engine/literals.py
+++ b/fhircraft/fhir/path/engine/literals.py
@@ -1,10 +1,16 @@
 import operator
+from pathlib import Path
 import re
 import warnings
 from abc import ABC
 from dataclasses import dataclass
 from datetime import date, datetime, time
 from typing import Optional, Union
+from pint import UnitRegistry, Quantity as PintQuantity
+
+# Load the Pint unit registry with UCUM definitions
+ureg = UnitRegistry()
+ureg.load_definitions(Path(__file__).resolve().parent / "ucum_to_pint.txt")
 
 
 class FHIRPathLiteralType(ABC):
@@ -16,20 +22,31 @@ class Quantity(FHIRPathLiteralType):
     value: Union[int, float]
     unit: Optional[str]
 
-    def __comparison__(self, other, op):
-        if self.unit == other.unit:
-            return op(self.value, other.value)
-        else:
-            warnings.warn(
-                f"Cannot perform operation {op.__name__} on quantities with different units: {self.unit} and {other.unit}. Returning empty collection."
+    def __comparison__(self, other, op) -> bool:
+        if isinstance(other, Quantity):
+            return op(
+                self.value * ureg(self.unit or ""), other.value * ureg(other.unit or "")
             )
-            return []
+        elif isinstance(other, (int, float)) and self.unit in (None, "1"):
+            return op(self.value, other)
+        else:
+            raise TypeError(f"Comparisons with {type(other)} not supported")
 
-    def __math__(self, other, op) -> "Quantity":
-        return Quantity(op(self.value, other.value), self.unit)
+    def __math__(self, other, op) -> PintQuantity:
+        if isinstance(other, Quantity):
+            return op(
+                self.value * ureg(self.unit or ""), other.value * ureg(other.unit or "")
+            )
+        elif isinstance(other, (int, float)):
+            return op(self.value, other)
+        else:
+            raise TypeError(f"Operations with {type(other)} not supported")
 
     def __abs__(self):
         return Quantity(abs(self.value), self.unit)
+
+    def __eq__(self, other):
+        return self.__comparison__(other, operator.eq)
 
     def __lt__(self, other):
         return self.__comparison__(other, operator.lt)
@@ -44,40 +61,39 @@ class Quantity(FHIRPathLiteralType):
         return self.__comparison__(other, operator.ge)
 
     def __add__(self, other):
-        if not self.unit == other.unit:
-            raise ValueError(
-                f"Cannot perform addition on quantities with different units: {self.unit} and {other.unit}."
-            )
-        return self.__math__(other, operator.add)
+        result = self.__math__(other, operator.add)
+        return Quantity(
+            value=result.to(self.unit).magnitude,
+            unit=self.unit,
+        )
 
     def __sub__(self, other):
-        if not self.unit == other.unit:
-            raise ValueError(
-                f"Cannot perform subtraction on quantities with different units: {self.unit} and {other.unit}."
-            )
-        return self.__math__(other, operator.sub)
+        result = self.__math__(other, operator.sub)
+        return Quantity(
+            value=result.to(self.unit).magnitude,
+            unit=self.unit,
+        )
 
     def __mul__(self, other):
         result = self.__math__(other, operator.mul)
-        result.unit = f"{self.unit}*{other.unit}"
-        return result
-
-    def __truediv__(self, other):
-        result = self.__math__(other, operator.truediv)
-        if self.unit == other.unit:
-            result.unit = "1"
-        else:
-            result.unit = f"{self.unit}/{other.unit}"
-        return result
+        return Quantity(
+            value=result.magnitude,
+            unit=f"{self.unit}*{other.unit}",
+        )
 
     def __floordiv__(self, other):
         result = self.__math__(other, operator.floordiv)
-        if self.unit == other.unit:
-            result.unit = "1"
-        else:
-            result.unit = f"{self.unit}/{other.unit}"
+        return Quantity(
+            value=result.magnitude,
+            unit=f"{self.unit}/{other.unit}" if self.unit != other.unit else "1",
+        )
 
-        return result
+    def __truediv__(self, other):
+        result = self.__math__(other, operator.truediv)
+        return Quantity(
+            value=result.magnitude,
+            unit=f"{self.unit}/{other.unit}" if self.unit != other.unit else "1",
+        )
 
 
 @dataclass

--- a/fhircraft/fhir/path/engine/math.py
+++ b/fhircraft/fhir/path/engine/math.py
@@ -235,14 +235,14 @@ class Division(FHIRMathOperator):
         )
         if left_value is None or right_value is None:
             return []
-        if right_value == 0:
-            return []
-        elif isinstance(left_value, (int, float)) and isinstance(
-            right_value, (int, float)
+        if (isinstance(right_value, Quantity) and right_value.value == 0) or (
+            isinstance(right_value, (int, float)) and right_value == 0
         ):
-            return [FHIRPathCollectionItem.wrap(left_value / right_value)]
-        elif isinstance(left_value, (Quantity)) and isinstance(right_value, (Quantity)):
-            return [FHIRPathCollectionItem.wrap(left_value / right_value)]
+            return []
+        elif isinstance(left_value, (int, float, Quantity)) and isinstance(
+            right_value, (int, float, Quantity)
+        ):
+            return [FHIRPathCollectionItem.wrap(left_value / right_value)]  # type: ignore
         else:
             raise FHIRPathRuntimeError(
                 f"FHIRPath operator {self.__str__()} cannot divide {type(left_value).__name__} and {type(right_value).__name__}."
@@ -283,17 +283,15 @@ class Div(FHIRMathOperator):
         )
         if left_value is None or right_value is None:
             return []
-        if right_value == 0:
-            return []
         elif isinstance(left_value, (int, float)) and isinstance(
             right_value, (int, float)
         ):
-            return [FHIRPathCollectionItem.wrap(left_value // right_value)]
-        elif isinstance(left_value, (Quantity)) and isinstance(right_value, (Quantity)):
-            return [FHIRPathCollectionItem.wrap(left_value // right_value)]
+            if right_value == 0:
+                return []
+            return [FHIRPathCollectionItem.wrap(left_value // right_value)]  # type: ignore
         else:
             raise FHIRPathRuntimeError(
-                f"FHIRPath operator {self.__str__()} cannot divide {type(left_value).__name__} and {type(right_value).__name__}."
+                f"FHIRPath operator {self.__str__()} cannot perform truncated division between {type(left_value).__name__} and {type(right_value).__name__}."
             )
 
     def __str__(self):

--- a/fhircraft/fhir/path/engine/ucum_to_pint.txt
+++ b/fhircraft/fhir/path/engine/ucum_to_pint.txt
@@ -1,0 +1,315 @@
+# Units definition file to extend pints default.txt with UCUM units
+# Language: english
+# Syntax: https://pint.readthedocs.io/en/stable/advanced/defining.html
+#
+# MIT License
+#
+# Copyright (c) 2024 David Linke
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Pint unit names, aliases and prefixes have to be valid python identifiers.
+# So UCUM units such as "10*", "10^" or "[gal_us]" are invalid unit names in pint.
+# We handle this by a mapping defined in ucum_pint.py
+# Example: [gal_us] -> Alias: "gal_us"
+#          cal[20] -> New unit: "twenty_degC_calorie" with alias "cal_20"
+
+#### CONSTANTS ####
+
+# Calculated using wolfram alpha to precision 50
+# slope = tan(1 rad), calculated as constant as tan()-function cannot be used in definitions
+slope = 1.5574077246549022305069748074583601730872507723815
+
+#### Prefixes ####
+# <prefix>- = <amount> [= <symbol>] [= <alias>] [ = <alias> ] [...]
+# Example:
+#     deca- =  1e+1  = da- = deka-
+
+#### UNITS ####
+# <canonical name> = <relation to another unit or dimension> [= <symbol>] [= <alias>] [ = <alias> ] [...]
+# The canonical name and aliases should be expressed in singular form.
+# If a unit has no symbol, then the symbol should be set to _.
+
+sphere = 4 * π * steradian = _ = sph
+
+ppth = 1e-3
+ppb = 1e-9
+pptr = 1e-12
+
+_10 = 10
+
+carat_of_gold_alloys = 1 / 24 = _ = car_Au
+Hounsfield_unit = 1 = _ = hnsf_U
+
+homeopathic_potency_of_decimal_series_retired = 1 = _ = hp_X
+homeopathic_potency_of_centesimal_series_retired = 1 = _ = hp_C
+homeopathic_potency_of_millesimal_series_retired = 1 = _ = hp_M
+homeopathic_potency_of_quintamillesimal_series_retired = 1 = _ = hp_Q
+homeopathic_potency_of_decimal_korsakovian_series = 1 = _ = kp_X
+homeopathic_potency_of_centesimal_korsakovian_series = 1 = _ = kp_C
+homeopathic_potency_of_millesimal_korsakovian_series = 1 = _ = kp_M
+homeopathic_potency_of_quintamillesimal_korsakovian_series = 1 = _ = kp_Q
+
+high_power_field = 1 = _ = HPF
+low_power_field = 1 = _ = LPF
+international_unit = 1 = _ = i.U. = IU = iU
+arbitrary_unit = 1 = _ = arb_U
+US_pharmacopeia_unit = 1 = _ = USP_U
+GPL_unit = 1 = _ = GPL_U
+MPL_unit = 1 = _ = MPL_U
+APL_unit = 1 = _ = APL_U
+Bethesda_unit = 1 = _ = beth_U
+anti_factor_Xa_unit = 1 = _ = anti_Xa_U
+Todd_unit = 1 = _ = todd_U
+Dye_unit = 1 = _ = dye_U
+Somogyi_unit = 1 = _ = smgy_U
+Bodansky_unit = 1 = _ = bdsk_U
+King_Armstrong_unit = 1 = _ = ka_U
+Kunkel_unit = 1 = _ = knk_U
+Mac_Lagan_unit = 1 = _ = mclg_U
+tuberculin_unit = 1 = _ = tb_U
+infectious_dose_cell_culture_50 =  1 = _ = CCID_50
+infectious_dose_tissue_culture_50 = 1 = _ = TCID_50
+infectious_dose_embryo_50 = 1 * 1 = EID_50
+plaque_forming_unit = 1 = PFU
+focus_forming_units = 1 = FFU
+colony_forming_unit = 1 = _ = CFU
+allergene_index_of_reactivity = 1 = IR
+bioequivalent_allergen_unit = 1 = BAU
+allergen_unit = 1
+allergen_unit_for_Ambrosia_artemisiifolia = 1 = _ = Amb_a_1_U
+protein_nitrogen_unit = 1 = PNU
+limit_of_flocculation = 1 = Lf
+D_antigen_unit = 1 = _ = D_ag_U
+fibrinogen_equivalent_unit = 1 = FEU
+ELISA_unit = 1 = ELU
+Ehrlich_unit = 1
+
+charrière = millimeter / 3 = _ = Ch
+inch_us = survey_foot / 12 = _ = in_us
+smoot = inch * 67
+
+mesh = 1 / inch = _ = mesh_i
+
+drop = milliliter / 20 = _ = drp
+equivalents = mol = eq
+osmole = mol = osm
+
+diopter = 1 / meter = _ = diop
+
+prism_diopter = 100 * slope = _ = p_diop
+
+nephelometric_turbidity_unit = 1 = _ = NTU
+formazin_nephelometric_unit = 1 = _ = FNU
+
+mil_i = inch / 1000
+cml_i = π/4 * mil_i**2
+hd_i = 4 * inch
+
+mil_us = inch_us / 1000
+
+metabolic_equivalent = 3.5 * milliliter / minute / kilogram = _ = MET
+peripheral_vascular_resistance_unit = millimeter_Hg * second / milliliter = _ = PRU
+Wood_unit = millimeter_Hg * minute / liter = _ =wood_U
+
+twenty_degC_calorie = 4.18190 * J = cal_20  # conversion factors from UCUM-v2.1
+mean_calorie = 4.19002 * J = cal_m  # conversion factors from UCUM-v2.1
+
+gregorian_month = gregorian_year/12 = mo_g
+
+meter_per_square_second_per_square_root_of_hertz = meter / sec**2 / Hz**(1/2)
+
+cord = 4 * 4 * 8 * international_foot**3 = _ = cr_i
+
+survey_yard = 3 * survey_foot = _ = yd_us
+Ramdens_chain = 100 * survey_foot = _ = rch_us
+link_for_Ramdens_chain = Ramdens_chain / 100 = _ = rlk_us
+township = survey_mile**2 * 36 = _ = twp
+
+international_fathom = 6 * international_foot = _ = fth_i
+
+printers_line = inch / 12 = _ = lne
+pied = 32.48 * centimeter  # French foot
+pouce = pied / 12  # French inch
+ligne = pouce / 12  # French line
+
+# old imperial units that should not be used but are defined in UCUM
+inch_imperial = 25.4000508 * millimeter = _ = in_br
+foot_imperial = 12 * inch_imperial = _ = ft_br
+rod_imperial = 16.5 * inch_imperial = _ = rd_br
+chain_imperial = 4 * rod_imperial = _ = ch_br
+link_imperial = chain_imperial / 100 = _ = lk_br
+fathom_imperial = 6 * foot_imperial = _ = fth_br
+pace_imperial = 2.5 * foot_imperial = _ = pc_br
+yard_imperial = 3 * foot_imperial = _ = yd_br
+mile_imperial = 5280* foot_imperial = _ = mi_br
+nautical_mile_imperial = 6080 * foot_imperial = _ = nmi_br
+knot_imperial = nautical_mile_imperial / hour = _ = kn_br
+acre_imperial = 4840 * yard_imperial**2 = _ = acr_br
+
+winchsester_gallon = bushel / 8 = _ = gal_wi
+
+fluid_ounce_metric = 30 * mL = _ = foz_m
+cup_metric = 240 * mL = _ = cup_m
+teaspoon_metric = 5 * mL = _ = tsp_m
+tablespoon_metric = 15 * mL = _ = tbs_m
+
+metric_ounce = 28 * gram = _ = oz_m
+
+phot = 1e-4 * lux
+
+british_thermal_unit_39F = 1.05967 * kJ = Btu_39
+british_thermal_unit_59F = 1.05480 * kJ = Btu_59
+british_thermal_unit_60F = 1.05468 * kJ = Btu_60
+british_thermal_unit_mean = 1.05587 * kJ = Btu_m
+
+# Logarithmic Unit Definition
+#  Unit = scale; logbase; logfactor
+#  x_dB = [logfactor] * log( x_lin / [scale] ) / log( [logbase] )
+bel = 1 ; logbase: 10; logfactor:
+
+# pH_value = 1 * mole / liter; logbase: 10; logfactor: -1  # mol/l is reduced to mol - A pint issue?
+
+bel_spl = 1 sound_pressure_level; logbase: 10; logfactor: 10 = B_SPL
+
+bel_volt = 1 volt; logbase: 10; logfactor: 10 = B_V
+bel_millivolt = 1 millivolt; logbase: 10; logfactor: 10 = B_mV
+bel_microvolt = 1 microvolt; logbase: 10; logfactor: 10 = B_uV
+bel_10nanovolt = 10 nanovolt; logbase: 10; logfactor: 10 = B_10nV
+
+bel_watt = 1 watt; logbase: 10; logfactor: 10 = B_W
+bel_kilowatt = 1 kilowatt; logbase: 10; logfactor: 10 = B_kW
+
+#### UNIT GROUPS ####
+
+#### Additional aliases ####
+# @alias <canonical name or previous alias> = <alias> [ = <alias> ] [...]
+
+@alias bit = bit_s
+
+@alias circle = circ
+
+@alias angstrom = Ao
+
+@alias are = ar
+@alias degree_Celsius = Cel
+
+@alias week = wk
+@alias month = mo = mo_j
+@alias tropical_year = a_t
+@alias year = a_j
+@alias gregorian_year = a_g
+@alias synodic_month = mo_s
+
+@alias ohm = Ohm
+
+@alias carat = car_m
+
+@alias international_inch = in_i
+@alias international_feet = ft_i
+@alias international_yard = yd_i
+
+@alias knot = kn_i
+@alias board_foot = bf_i
+
+@alias rod = rd_us
+@alias chain = ch_us
+@alias link = lk_us
+@alias survey_foot = ft_us
+@alias fathom = fth_us
+@alias furlong = fur_us
+@alias survey_mile = mi_us
+
+@alias square_inch = sin_i
+@alias square_foot = sft_i
+@alias square_yard = syd_i
+@alias square_survey_mile = smi_us = sct
+
+@alias acre = acr_us
+@alias square_rod = srd_us
+
+@alias cubic_inch = cin_i
+@alias fluid_ounce = foz_us
+@alias tablespoon = tbs_us
+@alias teaspoon = tsp_us
+
+@alias force_pound = lbf_av
+
+@alias stere = st
+
+@alias quart = qt_us
+@alias pint = pt_us
+@alias gill = gil_us
+@alias fluid_dram = fdr_us
+@alias bushel = bu_us
+@alias peck = pk_us
+@alias gallon = gal_us
+@alias oil_barrel = bbl_us
+
+@alias US_liquid_cup = cup_us
+
+@alias dram = dr_av
+@alias ounce = oz_av
+@alias pound = lb_av
+@alias stone = stone_av
+@alias short_hundredweight = scwt_av
+@alias long_hundredweight = lcwt_av
+@alias short_ton = ston_av
+@alias long_ton = lton_av
+@alias pennyweight = pwt_tr
+@alias troy_ounce = oz_tr
+@alias troy_pound = lb_tr
+
+@alias scruple = sc_ap
+@alias apothecary_dram = dr_ap
+@alias apothecary_ounce = oz_ap
+@alias apothecary_pound = lb_ap
+
+@alias imperial_gallon = gal_br
+@alias imperial_peck = pk_br
+@alias imperial_bushel = bu_br
+@alias imperial_quart = qt_br
+@alias imperial_pint = pt_br
+@alias imperial_gill = gil_br
+@alias imperial_fluid_ounce = foz_br
+@alias imperial_fluid_dram = fdr_br
+@alias imperial_minim = minim_br
+
+@alias reciprocal_centimeter = Ky
+@alias stilb = sb
+@alias lambert = Lmb
+@alias rads = RAD
+@alias rem = REM
+
+@alias technical_atmosphere = att
+@alias inch_H2O_60F = in_i_H2O   # UCUM v2.1 does not give a temperature in the definition
+@alias inch_Hg_60F = in_i_Hg   # UCUM v2.1 does not give a temperature in the definition
+
+@alias international_calorie = cal_IT
+@alias calorie = Cal
+@alias byte = By
+
+@alias international_british_thermal_unit = Btu_IT
+
+@alias horsepower = HP
+
+@alias pica = pca
+@alias point = pnt
+@alias tex_point = pnt_pr
+@alias tex_pica = pca_pr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     'jsonschema>4',
     'jsonpath-ng>1',
     'jinja2>=3.1',
+    'Pint>=0.24',
 ]
 
 [project.optional-dependencies]

--- a/test/test_fhir_path_engine_literals.py
+++ b/test/test_fhir_path_engine_literals.py
@@ -8,27 +8,42 @@ def test_fhirpath_type_quantity_init():
 
 def test_fhirpath_type_quantity_eq():
     assert Quantity(value=1, unit="m") == Quantity(value=1, unit="m")
+    assert Quantity(value=1, unit="m") == Quantity(value=100, unit="cm")
+    assert Quantity(value=1, unit="km") == Quantity(value=100000, unit="cm")
 
 
 def test_fhirpath_type_quantity_gt():
     assert Quantity(value=2, unit="m") > Quantity(value=1, unit="m")
+    assert Quantity(value=2, unit="m") > Quantity(value=100, unit="cm")
+    assert Quantity(value=1, unit="km") > Quantity(value=1, unit="m")
 
 
 def test_fhirpath_type_quantity_lt():
     assert Quantity(value=1, unit="m") < Quantity(value=2, unit="m")
+    assert Quantity(value=1, unit="m") < Quantity(value=200, unit="cm")
+    assert Quantity(value=1, unit="m") < Quantity(value=1, unit="km")
 
 
 def test_fhirpath_type_quantity_ge():
     assert Quantity(value=2, unit="m") >= Quantity(value=1, unit="m")
+    assert Quantity(value=1, unit="km") >= Quantity(value=1, unit="m")
 
 
 def test_fhirpath_type_quantity_le():
     assert Quantity(value=1, unit="m") <= Quantity(value=2, unit="m")
+    assert Quantity(value=1, unit="m") <= Quantity(value=200, unit="cm")
+    assert Quantity(value=1, unit="m") <= Quantity(value=1, unit="km")
 
 
 def test_fhirpath_type_quantity_add():
     assert Quantity(value=2, unit="m") + Quantity(value=2, unit="m") == Quantity(
         value=4, unit="m"
+    )
+    assert Quantity(value=2, unit="m") + Quantity(value=2, unit="cm") == Quantity(
+        value=2.02, unit="m"
+    )
+    assert Quantity(value=1, unit="g") + Quantity(value=1, unit="kg") == Quantity(
+        value=1001, unit="g"
     )
 
 
@@ -36,11 +51,20 @@ def test_fhirpath_type_quantity_sub():
     assert Quantity(value=2, unit="m") - Quantity(value=2, unit="m") == Quantity(
         value=0, unit="m"
     )
+    assert Quantity(value=2, unit="m") - Quantity(value=20, unit="cm") == Quantity(
+        value=1.8, unit="m"
+    )
+    assert Quantity(value=1, unit="kg") - Quantity(value=500, unit="g") == Quantity(
+        value=0.5, unit="kg"
+    )
 
 
 def test_fhirpath_type_quantity_prod():
     assert Quantity(value=3, unit="m") * Quantity(value=2, unit="s") == Quantity(
         value=6, unit="m*s"
+    )
+    assert Quantity(value=3, unit="m") * Quantity(value=2, unit="m") == Quantity(
+        value=6, unit="m*m"
     )
 
 
@@ -58,10 +82,6 @@ def test_fhirpath_type_quantity_div_same_unit():
 
 def test_fhirpath_type_quantity_abs():
     assert abs(Quantity(value=-3, unit="m")) == Quantity(value=3, unit="m")
-
-
-def test_fhirpath_type_quantity_different_units():
-    assert (Quantity(value=1, unit="cm") <= Quantity(value=2, unit="m")) == []
 
 
 def test_fhirpath_type_date_init():

--- a/test/test_fhir_path_engine_math.py
+++ b/test/test_fhir_path_engine_math.py
@@ -131,8 +131,6 @@ div_cases = (
     (5, 2, 2),
     (5.5, 0.7, 7),
     (5, 0, []),
-    (Quantity(4, "mg"), Quantity(2, "mg"), Quantity(2, "1")),
-    (Quantity(4, "mg"), Quantity(2, "L"), Quantity(2, "mg/L")),
 )
 
 


### PR DESCRIPTION
This pull request introduces comprehensive support for unit-aware arithmetic and comparison operations for the `Quantity` type in the FHIRPath engine, leveraging the Pint library and a custom UCUM unit definition file. The changes ensure that quantities with different but convertible units are correctly handled in mathematical and comparison operations, improving standards compliance and correctness. It also updates relevant tests to cover these new behaviors.

## Added

* Implented the Pint library `Quantity` class and integrated the UCUM unit definitions via a new `ucum_to_pint.txt` file, enabling robust unit conversion and arithmetic for `Quantity` values. 
   * The  `ucum_to_pint.txt` is an MIT licensed copy of  [`pint_ucum_defs.txt`](https://github.com/dalito/ucumvert/blob/main/src/ucumvert/pint_ucum_defs.txt) from hte `ucumvert` package. In the future, once `ucumvert` reaches a more mature state in its public API, we can directly interface through it.
* Refactored the FHIRPath `Quantity` class to use Pint for all arithmetic and comparison operations, allowing operations between quantities with convertible units and raising errors for unsupported types.
* Closes #36 

