### PR TITLE
Fix polymorphic serialization check in FHIRBaseModel

### DIFF
--- a/fhircraft/fhir/resources/base.py
+++ b/fhircraft/fhir/resources/base.py
@@ -83,7 +83,7 @@ class FHIRBaseModel(BaseModel, FHIRPathMixin):
     def _serialize_polymorphic_fields(self, serializer, info) -> Any:
         """Apply polymorphic serialization to FHIR fields during serialization."""
         # Check if polymorphic serialization is enabled
-        if not self._enable_polymorphic_serialization:
+        if not isinstance(self, FHIRBaseModel) or not self._enable_polymorphic_serialization:
             return serializer(self)
 
         # Get the base serialization with warnings suppressed


### PR DESCRIPTION
This pull request introduces a minor correction to the polymorphic serialization logic in the FHIR resource base model. The main change is an additional type check to ensure that polymorphic serialization is only attempted on instances of `FHIRBaseModel`.

### Fixed 
  * Updated the `_serialize_polymorphic_fields` method in `fhircraft/fhir/resources/base.py` to check if `self` is an instance of `FHIRBaseModel` before proceeding with polymorphic serialization. This prevents errors when the method is called on objects that are not FHIR models. Fixes #129 