### PR TITLE
Change log level from info to debug for FHIRPath trace logging

### DIFF
--- a/fhircraft/fhir/path/engine/utility.py
+++ b/fhircraft/fhir/path/engine/utility.py
@@ -57,8 +57,8 @@ class Trace(FHIRPathFunction):
             log_collection = Select(self.projection).evaluate(
                 collection, environment, create
             )
-        logger.info(
-            f"{self.name} - {[str(item.value) if isinstance(item, FHIRPathCollectionItem) else str(item) for item in ensure_list(log_collection)]}"
+        logger.debug(
+            f"FHIRPath trace: {self.name} - {[str(item.value) if isinstance(item, FHIRPathCollectionItem) else str(item) for item in ensure_list(log_collection)]}"
         )
         return collection
 


### PR DESCRIPTION
This pull request makes a minor change to the logging level in the FHIRPath `trace` function The log statement now uses the debug level instead of info, which will reduce log verbosity in production environments.

### Changed

* Changed the logging level from `info` to `debug` for FHIRPath trace logs in the `evaluate` function in `fhircraft/fhir/path/engine/utility.py`. 
* Towards  addressing  #146  