### PR TITLE
Add `packaging` module as a direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     'jsonpath-ng>1',
     'jinja2>=3.1',
     'Pint>=0.24',
+    'packaging>=25'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pull request adds a new dependency to the project.

### Fixed
  * Added `packaging>=25` to the `dependencies` list in `pyproject.toml`. Fixes #148 