### PR TITLE
Fix equality operator representation in FHIRPath

### DIFF
--- a/fhircraft/fhir/path/engine/equality.py
+++ b/fhircraft/fhir/path/engine/equality.py
@@ -69,7 +69,7 @@ class Equals(FHIRPath):
         return [FHIRPathCollectionItem.wrap(equals)]
 
     def __str__(self):
-        return f"{self.left} == {self.right}"
+        return f"{self.left} = {self.right}"
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.left!s}, {self.right!s})"

--- a/test/test_fhir_mapper_lexer.py
+++ b/test/test_fhir_mapper_lexer.py
@@ -210,6 +210,20 @@ token_test_cases = (
         ),
     ),
     (
+        "where(a = 10) -> create patient",
+        (
+            ("where", "WHERE"),
+            ("(", "("),
+            ("a", "IDENTIFIER"),
+            ("=", "EQUAL"),
+            (10, "INTEGER"),
+            (")", ")"),
+            ("->", "RIGHT_ARROW"),
+            ("create", "IDENTIFIER"),
+            ("patient", "IDENTIFIER"),
+        ),
+    ),
+    (
         "check src.exists()",
         (
             ("check", "CHECK"),

--- a/test/test_fhir_mapper_parser.py
+++ b/test/test_fhir_mapper_parser.py
@@ -707,6 +707,29 @@ parser_test_cases = (
         ),
     ),
     (
+        """group map_example(source src, target tgt){src.field as f where(f = 10) -> tgt.field;}""",
+        add_rules_to_basic_map(
+            rules=[
+                StructureMapGroupRule(
+                    source=[
+                        StructureMapGroupRuleSource(
+                            context="src",
+                            element="field",
+                            condition="f = 10",
+                            variable="f",
+                        )
+                    ],
+                    target=[
+                        StructureMapGroupRuleTarget(
+                            context="tgt",
+                            element="field",
+                        )
+                    ],
+                )
+            ]
+        ),
+    ),
+    (
         """group map_example(source src, target tgt){src.field as f where(f > 10) -> tgt.field;}""",
         add_rules_to_basic_map(
             rules=[

--- a/test/test_fhir_path_engine_equality.py
+++ b/test/test_fhir_path_engine_equality.py
@@ -51,7 +51,7 @@ def test_equals_returns_correct_boolean(left, right, expected):
 
 def test_equals_string_representation():
     expression = Equals(Element("left"), Element("right"))
-    assert str(expression) == "left == right"
+    assert str(expression) == "left = right"
 
 
 @pytest.mark.parametrize("left, right, expected", equals_boolean_logic_cases)


### PR DESCRIPTION
This pull request updates the equality operator representation in the FHIRPath engine to use a single equals sign (`=`) instead of a double equals (`==`). It also adds corresponding test cases to ensure proper tokenization and parsing of the new equality syntax in the lexer and parser.

### Fixed 

* Changed the string representation of the `Equals` class in `fhircraft/fhir/path/engine/equality.py` from `==` to `=` to align with FHIRPath syntax. Fixes #162 and #161 


### Tests
* Updated the related test in `test/test_fhir_path_engine_equality.py` to expect `=` instead of `==`.
* Added a lexer test in `test/test_fhir_mapper_lexer.py` to ensure the `=` operator is correctly tokenized as `EQUAL`.
* Added a parser test in `test/test_fhir_mapper_parser.py` to verify parsing of rules using the `=` operator in conditions.