### PR TITLE
Refactor `FHIRPathMixin` methods to include optional `environment` argument

### DIFF
--- a/fhircraft/fhir/path/mixin.py
+++ b/fhircraft/fhir/path/mixin.py
@@ -14,11 +14,10 @@ class FHIRPathMixin:
     on FHIR resource instances, leveraging the enhanced FHIRPath interface.
     """
 
-
     def _generate_fhirpath_environment(self):
         environment = {}
-        if release := getattr(self, '_fhir_release', None):
-            environment['%fhirRelease'] = FHIRPathCollectionItem.wrap(release)
+        if release := getattr(self, "_fhir_release", None):
+            environment["%fhirRelease"] = FHIRPathCollectionItem.wrap(release)
         return environment
 
     @property
@@ -29,7 +28,9 @@ class FHIRPathMixin:
         return import_fhirpath_engine()
 
     # Enhanced interface methods
-    def fhirpath_values(self, expression: str) -> List[Any]:
+    def fhirpath_values(
+        self, expression: str, environment: dict | None = None
+    ) -> List[Any]:
         """
         Evaluates a FHIRPath expression and returns all matching values as a list.
 
@@ -39,16 +40,26 @@ class FHIRPathMixin:
         Returns:
             List[Any]: A list of all values that match the FHIRPath expression.
                       Returns an empty list if no matches are found.
+            environment (dict | None): Optional environment variables for evaluation
         """
-        return self.fhirpath.parse(expression).values(self, environment=self._generate_fhirpath_environment())
+        return self.fhirpath.parse(expression).values(
+            self,
+            environment={
+                **self._generate_fhirpath_environment(),
+                **(environment or {}),
+            },
+        )
 
-    def fhirpath_single(self, expression: str, default: Any = None) -> Any:
+    def fhirpath_single(
+        self, expression: str, default: Any = None, environment: dict | None = None
+    ) -> Any:
         """
         Evaluates a FHIRPath expression and returns exactly one value.
 
         Args:
             expression (str): FHIRPath expression to evaluate
             default: The default value to return if no matches are found
+            environment (dict | None): Optional environment variables for evaluation
 
         Returns:
             Any: The single matching value
@@ -56,93 +67,163 @@ class FHIRPathMixin:
         Raises:
             FHIRPathRuntimeError: If more than one value is found
         """
-        return self.fhirpath.parse(expression).single(self, default=default, environment=self._generate_fhirpath_environment())
+        return self.fhirpath.parse(expression).single(
+            self,
+            default=default,
+            environment={
+                **self._generate_fhirpath_environment(),
+                **(environment or {}),
+            },
+        )
 
-    def fhirpath_first(self, expression: str, default: Any = None) -> Any:
+    def fhirpath_first(
+        self, expression: str, default: Any = None, environment: dict | None = None
+    ) -> Any:
         """
         Evaluates a FHIRPath expression and returns the first matching value.
 
         Args:
             expression (str): FHIRPath expression to evaluate
             default: The default value to return if no matches are found
+            environment (dict | None): Optional environment variables for evaluation
 
         Returns:
             Any: The first matching value, or the default if no matches
         """
-        return self.fhirpath.parse(expression).first(self, default=default, environment=self._generate_fhirpath_environment())
+        return self.fhirpath.parse(expression).first(
+            self,
+            default=default,
+            environment={
+                **self._generate_fhirpath_environment(),
+                **(environment or {}),
+            },
+        )
 
-    def fhirpath_last(self, expression: str, default: Any = None) -> Any:
+    def fhirpath_last(
+        self, expression: str, default: Any = None, environment: dict | None = None
+    ) -> Any:
         """
         Evaluates a FHIRPath expression and returns the last matching value.
 
         Args:
             expression (str): FHIRPath expression to evaluate
             default: The default value to return if no matches are found
+            environment (dict | None): Optional environment variables for evaluation
 
         Returns:
             Any: The last matching value, or the default if no matches
         """
-        return self.fhirpath.parse(expression).last(self, default=default, environment=self._generate_fhirpath_environment())
+        return self.fhirpath.parse(expression).last(
+            self,
+            default=default,
+            environment={
+                **self._generate_fhirpath_environment(),
+                **(environment or {}),
+            },
+        )
 
-    def fhirpath_exists(self, expression: str) -> bool:
+    def fhirpath_exists(self, expression: str, environment: dict | None = None) -> bool:
         """
         Checks if a FHIRPath expression matches any values.
 
         Args:
             expression (str): FHIRPath expression to evaluate
+            environment (dict | None): Optional environment variables for evaluation
 
         Returns:
             bool: True if at least one value matches, False otherwise
         """
-        return self.fhirpath.parse(expression).exists(self, environment=self._generate_fhirpath_environment())
+        return self.fhirpath.parse(expression).exists(
+            self,
+            environment={
+                **self._generate_fhirpath_environment(),
+                **(environment or {}),
+            },
+        )
 
-    def fhirpath_is_empty(self, expression: str) -> bool:
+    def fhirpath_is_empty(
+        self, expression: str, environment: dict | None = None
+    ) -> bool:
         """
         Checks if a FHIRPath expression matches no values.
 
         Args:
             expression (str): FHIRPath expression to evaluate
+            environment (dict | None): Optional environment variables for evaluation
 
         Returns:
             bool: True if no values match, False otherwise
         """
-        return self.fhirpath.parse(expression).is_empty(self, environment=self._generate_fhirpath_environment())
+        return self.fhirpath.parse(expression).is_empty(
+            self,
+            environment={
+                **self._generate_fhirpath_environment(),
+                **(environment or {}),
+            },
+        )
 
-    def fhirpath_count(self, expression: str) -> int:
+    def fhirpath_count(self, expression: str, environment: dict | None = None) -> int:
         """
         Returns the number of values that match a FHIRPath expression.
 
         Args:
             expression (str): FHIRPath expression to evaluate
+            environment (dict | None): Optional environment variables for evaluation
 
         Returns:
             int: The number of matching values
         """
-        return self.fhirpath.parse(expression).count(self, environment=self._generate_fhirpath_environment())
+        return self.fhirpath.parse(expression).count(
+            self,
+            environment={
+                **self._generate_fhirpath_environment(),
+                **(environment or {}),
+            },
+        )
 
-    def fhirpath_update_values(self, expression: str, value: Any) -> None:
+    def fhirpath_update_values(
+        self, expression: str, value: Any, environment: dict | None = None
+    ) -> None:
         """
         Evaluates a FHIRPath expression and sets all matching locations to the given value.
 
         Args:
             expression (str): FHIRPath expression to evaluate
             value (Any): The value to set at all matching locations
+            environment (dict | None): Optional environment variables for evaluation
 
         Raises:
             RuntimeError: If no matching locations are found or if locations cannot be set
         """
-        self.fhirpath.parse(expression).update_values(self, value, environment=self._generate_fhirpath_environment())
+        self.fhirpath.parse(expression).update_values(
+            self,
+            value,
+            environment={
+                **self._generate_fhirpath_environment(),
+                **(environment or {}),
+            },
+        )
 
-    def fhirpath_update_single(self, expression: str, value: Any) -> None:
+    def fhirpath_update_single(
+        self, expression: str, value: Any, environment: dict | None = None
+    ) -> None:
         """
         Evaluates a FHIRPath expression and sets exactly one matching location to the given value.
 
         Args:
             expression (str): FHIRPath expression to evaluate
             value (Any): The value to set at the matching location
+            environment (dict | None): Optional environment variables for evaluation
 
         Raises:
             FHIRPathError: If zero or more than one matching locations are found
             RuntimeError: If the location cannot be set
         """
-        self.fhirpath.parse(expression).update_single(self, value, environment=self._generate_fhirpath_environment())
+        self.fhirpath.parse(expression).update_single(
+            self,
+            value,
+            environment={
+                **self._generate_fhirpath_environment(),
+                **(environment or {}),
+            },
+        )


### PR DESCRIPTION
This pull request enhances the flexibility of the FHIRPath evaluation methods in the `FHIRPathMixin` class by allowing users to provide custom environment variables for FHIRPath expression evaluation. Each FHIRPath-related method now accepts an optional `environment` parameter, which is merged with the default environment, enabling more dynamic and context-aware FHIRPath queries.

**Changed**

* All FHIRPath interface methods (`fhirpath_values`, `fhirpath_single`, `fhirpath_first`, `fhirpath_last`, `fhirpath_exists`, `fhirpath_is_empty`, `fhirpath_count`, `fhirpath_update_values`, and `fhirpath_update_single`) now accept an optional `environment` dictionary parameter, which is merged with the default environment for evaluation.  Closes #166 