### PR TITLE
Fix FHIRPath quote handling for unquoted expressions with string literals

### DIFF
--- a/fhircraft/fhir/mapper/parser.py
+++ b/fhircraft/fhir/mapper/parser.py
@@ -1034,7 +1034,8 @@ class FhirMappingLanguageParser(FhirPathParser):
         """
         m_fhirpath : expression
         """
-        p[0] = str(p[1]).strip("'")
+        expr = str(p[1])
+        p[0] = expr.strip('\'') if expr.startswith('\'') and expr.endswith('\'') else expr
 
     def p_mapper_url(self, p):
         """


### PR DESCRIPTION
This pull request fixes a bug in the FHIR Mapping Language parser, ensuring that only FHIRPath quoted-strings with both leading and trailing single quotes have those quotes stripped, rather than always stripping them.

Example:
```
# Must be stripped 
... where('$this = 1')
# Must not be stripped 
... where($this = 'string')
```

### Fixed 
- Improved the logic in FHIR Mapping Language parser `p_mapper_fhirpath` to strip single quotes only when both the start and end of the string are single quotes to avoid errors when using unquoted FHIRPaths ending in a string literal. 