### PR TITLE
Fix FHIRPath Lexer to Correctly Handle Escaped Single Quotes in Strings

### DIFF
--- a/fhircraft/fhir/path/lexer.py
+++ b/fhircraft/fhir/path/lexer.py
@@ -412,7 +412,7 @@ class FhirPathLexer(metaclass=MergeLexerMetaclass):
         # The String type represents string values up to 231-1 characters in length. String
         # literals are surrounded by single-quotes and may use \-escapes to escape quotes
         # and represent Unicode characters
-        r"\'([^\']*)?\'"
+        r"\'((?:[^\'\\]|\\.)*)\'"
         t.value = t.value.strip("'")
         return t
 

--- a/test/test_fhir_path_lexer.py
+++ b/test/test_fhir_path_lexer.py
@@ -11,7 +11,10 @@ token_test_cases = (
     # -------- Environmental Operators -----------
     ("%resource", (("%resource", "ENVIRONMENTAL_VARIABLE"),)),
     ("%context", (("%context", "ENVIRONMENTAL_VARIABLE"),)),
-    ("%`custom-named-variable`", (("%`custom-named-variable`", "ENVIRONMENTAL_VARIABLE"),)),
+    (
+        "%`custom-named-variable`",
+        (("%`custom-named-variable`", "ENVIRONMENTAL_VARIABLE"),),
+    ),
     # ----------------- Symbols -----------------
     (".", ((".", "."),)),
     (",", ((",", ","),)),
@@ -25,6 +28,12 @@ token_test_cases = (
     (")", ((")", ")"),)),
     ("}", (("}", "}"),)),
     ("{", (("{", "{"),)),
+    # ----------------- Escaped Unicode Strings ------------------
+    ("'\"'", (('"', "STRING"),)),
+    ("'\r'", (("\r", "STRING"),)),
+    ("'\n'", (("\n", "STRING"),)),
+    ("'\t'", (("\t", "STRING"),)),
+    ("'\f'", (("\f", "STRING"),)),
     # ----------------- Literals -----------------
     ("// comment line", ()),
     ("/* multiline \n comment */", ()),


### PR DESCRIPTION
This pull request improves the handling of string literals in the FHIRPath lexer to correctly support escape sequences (such as Unicode and special characters) and adds corresponding test cases to ensure proper parsing.

### Fixed

* Updated the string literal regular expression in `fhircraft/fhir/path/lexer.py` to correctly handle escaped characters within single-quoted strings, allowing for escape sequences like `\'`. Fixes #174 