### PR TITLE
Remove unused `DOCUMENTATION` token from FML lexer to suppress warnings

### DIFF
--- a/fhircraft/fhir/mapper/lexer.py
+++ b/fhircraft/fhir/mapper/lexer.py
@@ -113,7 +113,6 @@ class FhirMappingLanguageLexer(FhirPathLexer):
         "IDENTIFIER",
         "DELIMITEDIDENTIFIER",
         "METADATA_DECLARATION",
-        "DOCUMENTATION",
         "GROUPTYPE",
         "INTEGER",
         "DECIMAL",


### PR DESCRIPTION
### Fixed

* This pull request makes a small change to the lexer in `fhircraft/fhir/mapper/lexer.py` by removing the "DOCUMENTATION" token type from the list of recognized tokens to suppress the `Token 'DOCUMENTATION' defined, but not used` and `There is 1 unused token` warnings.