### PR TITLE
Fix FHIRPath `Union` Operation `TypeError` with Incomparable Types

### DIFF
--- a/fhircraft/fhir/path/engine/combining.py
+++ b/fhircraft/fhir/path/engine/combining.py
@@ -40,10 +40,7 @@ class Union(FHIRPathFunction):
             )
         return [
             FHIRPathCollectionItem.wrap(item)
-            for item in sorted(
-                list(set(collection) | set(self.other_collection)),
-                key=lambda item: item.value,
-            )
+            for item in list(set(self.other_collection) | set(collection))
         ]
 
 

--- a/test/test_fhir_path_engine_collection.py
+++ b/test/test_fhir_path_engine_collection.py
@@ -18,14 +18,16 @@ def test_union_returns_combined_collection_without_duplicates():
         Invocation(Element("left"), GetValue()),
         Invocation(Element("right"), GetValue()),
     ).evaluate(collection, env)
-    assert result == [
+    assert set(result) == {
         FHIRPathCollectionItem(value="A"),
         FHIRPathCollectionItem(value="B"),
-    ]
+    }
+
 
 def test_union_string_representation():
     expression = Union(Element("left"), Element("right"))
     assert str(expression) == "left | right"
+
 
 # -------------
 # In
@@ -40,6 +42,7 @@ def test_in_returns_empty_if_left_empty():
     result = In([], Element("right")).evaluate(collection, env)
     result = result[0].value if len(result) == 1 else result
     assert result == []
+
 
 def test_in_returns_false_if_right_empty():
     resource = namedtuple("Resource", ["left", "right"])(
@@ -62,9 +65,11 @@ def test_in_checks_membership_correctly():
     result = result[0].value if len(result) == 1 else result
     assert result == True
 
+
 def test_in_string_representation():
     expression = In(Element("left"), Element("right"))
     assert str(expression) == "left in right"
+
 
 # -------------
 # Contains
@@ -101,6 +106,7 @@ def test_contains_checks_containership_correctly():
     )
     result = result[0].value if len(result) == 1 else result
     assert result == True
+
 
 def test_contains_string_representation():
     expression = Contains(Element("left"), Element("right"))

--- a/test/test_fhir_path_engine_combining.py
+++ b/test/test_fhir_path_engine_combining.py
@@ -1,33 +1,82 @@
 from fhircraft.fhir.path.engine.core import FHIRPathCollectionItem, Element
 from fhircraft.fhir.path.engine.combining import *
-        
+from dataclasses import dataclass
+
+
+@dataclass
+class ComplexItem:
+    id: str
+    value: str
+
+
 env = dict()
 
-#-------------
+# -------------
 # Union
-#-------------
+# -------------
+
 
 def test_union_returns_combined_collection_without_duplicates():
-    collection = [FHIRPathCollectionItem(value="item1"), FHIRPathCollectionItem(value="item1")]
+    collection = [
+        FHIRPathCollectionItem(value="item1"),
+        FHIRPathCollectionItem(value="item1"),
+    ]
     other_collection = [FHIRPathCollectionItem(value="item2")]
     result = Union(other_collection).evaluate(collection, env)
-    assert result == [FHIRPathCollectionItem(value="item1"), FHIRPathCollectionItem(value="item2")]
+    assert set(result) == {
+        FHIRPathCollectionItem(value="item1"),
+        FHIRPathCollectionItem(value="item2"),
+    }
+
+
+def test_union_returns_combined_collection_with_complex_items():
+    collection = [FHIRPathCollectionItem(value=ComplexItem(id="item1", value="value1"))]
+    other_collection = [
+        FHIRPathCollectionItem(value=ComplexItem(id="item2", value="value2"))
+    ]
+    result = Union(other_collection).evaluate(collection, env)
+    assert set(result) == {
+        FHIRPathCollectionItem(value=ComplexItem(id="item1", value="value1")),
+        FHIRPathCollectionItem(value=ComplexItem(id="item2", value="value2")),
+    }
+
 
 def test_union_string_representation():
     expression = Union(Element("other"))
     assert str(expression) == "union(other)"
 
-    
-#-------------
+
+# -------------
 # Combine
-#-------------
+# -------------
+
 
 def test_combine_returns_combined_collection_with_duplicates():
-    collection = [FHIRPathCollectionItem(value="item1"), FHIRPathCollectionItem(value="item1")]
+    collection = [
+        FHIRPathCollectionItem(value="item1"),
+        FHIRPathCollectionItem(value="item1"),
+    ]
     other_collection = [FHIRPathCollectionItem(value="item2")]
     result = Combine(other_collection).evaluate(collection, env)
-    assert result == [FHIRPathCollectionItem(value="item1"), FHIRPathCollectionItem(value="item1"), FHIRPathCollectionItem(value="item2")]
-    
+    assert set(result) == {
+        FHIRPathCollectionItem(value="item1"),
+        FHIRPathCollectionItem(value="item1"),
+        FHIRPathCollectionItem(value="item2"),
+    }
+
+
+def test_combine_returns_combined_collection_with_complex_items():
+    collection = [FHIRPathCollectionItem(value=ComplexItem(id="item1", value="value1"))]
+    other_collection = [
+        FHIRPathCollectionItem(value=ComplexItem(id="item2", value="value2"))
+    ]
+    result = Combine(other_collection).evaluate(collection, env)
+    assert set(result) == {
+        FHIRPathCollectionItem(value=ComplexItem(id="item1", value="value1")),
+        FHIRPathCollectionItem(value=ComplexItem(id="item2", value="value2")),
+    }
+
+
 def test_combine_string_representation():
     expression = Combine(Element("other"))
     assert str(expression) == "combine(other)"


### PR DESCRIPTION
Fixed a `TypeError` in FHIRPath `Union` operation by removing unnecessary sorting that failed when collections contained incomparable types. The union operation now uses simple set merging without ordering, which aligns with the FHIRPath specification and prevents crashes when combining collections with different object types like Pydantic models Updated tests to handle unordered results and added coverage for complex data types.

### Fixed

* Removed unnecessary `sorted()` function from FHIRPath Union operation to prevent `TypeError` when comparing incomparable types like Pydantic models or generic objects. Fixes #194 