### PR TITLE
Ensure FHIRPaths using reserved Python keywords evaluate to the correct model field

### DIFF
--- a/fhircraft/fhir/path/engine/core.py
+++ b/fhircraft/fhir/path/engine/core.py
@@ -798,6 +798,10 @@ class Element(FHIRPath):
         child_collection = self._get_collection_by_label(collection, self.label, create)
         if not child_collection:
             child_collection = self._get_collection_by_label(
+                collection, f"{self.label}_", create
+            )
+        if not child_collection:
+            child_collection = self._get_collection_by_label(
                 collection, f"{self.label}_ext", create
             )
         if not child_collection and self.label in ["id", "extension"]:

--- a/test/test_fhir_path_engine_core.py
+++ b/test/test_fhir_path_engine_core.py
@@ -171,6 +171,7 @@ class TestElement(TestCase):
             def __init__(self):
                 self.status = "active"
                 self.valueString = None
+                self.class_ = "classValue"
                 self.valueString_ext = {
                     type("Extension", (), {"valueId": "id1"})(),
                 }
@@ -191,6 +192,12 @@ class TestElement(TestCase):
         result = Element("status").evaluate(self.collection, env, create=False)
         assert len(result) == 1
         assert result[0].value == "active"
+
+    def test_evaluate_returns_correct_value_for_reserved_keywords(self):
+        # Should return the value of the field as a FHIRPathCollectionItem
+        result = Element("class").evaluate(self.collection, env, create=False)
+        assert len(result) == 1
+        assert result[0].value == "classValue"
 
     def test_evaluate_returns_empty_when_field_missing_and_create_false(self):
         # Should return empty list if field does not exist and create is False


### PR DESCRIPTION
This pull request improves the handling of reserved keywords as field names in the FHIRPath engine and adds corresponding test coverage. 

### Fixed 

* Updated the `evaluate` method in `fhircraft/fhir/path/engine/core.py` to check for field names that may conflict with reserved Python keywords by also looking for attributes with an underscore suffix (e.g., `class_`) if the original label is not found.
