### PR TITLE
Enable automatic conversion of offset units for Pint UnitRegistry

### DIFF
--- a/fhircraft/fhir/path/engine/literals.py
+++ b/fhircraft/fhir/path/engine/literals.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from fhircraft.fhir.resources.datatypes.R5.complex.quantity import Quantity as R5_Quantity
 
 # Load the Pint unit registry with UCUM definitions
-ureg = UnitRegistry()
+ureg = UnitRegistry(autoconvert_offset_to_baseunit=True)
 ureg.load_definitions(Path(__file__).resolve().parent / "ucum_to_pint.txt")
 
 


### PR DESCRIPTION
This pull request makes a minor configuration change to the Pint unit registry used for unit handling in the FHIR Path engine. The change enables automatic conversion of offset units to their base units, which can help prevent subtle unit conversion errors.

### Fixed 
* Updated the initialization of `UnitRegistry` in `literals.py` to set `autoconvert_offset_to_baseunit=True`, ensuring offset units are automatically converted to their base units. Fixes #242