### PR TITLE
 Enable polymorphic deserialization for profile models with parent class instances

### DIFF
--- a/fhircraft/fhir/resources/base.py
+++ b/fhircraft/fhir/resources/base.py
@@ -142,33 +142,58 @@ class FHIRBaseModel(BaseModel, FHIRPathMixin):
         field_info = cls.model_fields[field_name]
         base_type = cls._get_field_base_type(field_info)
 
-        # Only apply to FHIR fields
-        if (
+        # Check if polymorphic deserialization should apply:
+        # 1. Abstract FHIR base types (always)
+        # 2. Non-abstract FHIR types when receiving an instance of a parent class
+        should_apply_polymorphic = (
             base_type != object
             and hasattr(base_type, "__mro__")
             and issubclass(base_type, FHIRBaseModel)
-            and base_type._abstract is True
-        ):
-            # Create a unique key for this deserialization context
-            context_key = (cls, field_name, base_type)
-            stack = _get_polymorphic_deserialization_stack()
+        )
 
-            # Check if we're already processing this context to prevent recursion
-            if context_key in stack:
-                return value
+        if not should_apply_polymorphic:
+            return value
 
-            # Add to stack and process
-            stack.add(context_key)
-            try:
-                result = cls._deserialize_polymorphically(value, base_type)
-                return result
-            except Exception:
-                return value
-            finally:
-                # Always remove from stack when done
-                stack.discard(context_key)
+        # Check if this is an abstract type or if we're receiving a parent class instance
+        is_abstract = base_type._abstract is True
 
-        return value
+        # Check if we have a parent class instance
+        is_parent_instance = False
+        if isinstance(value, FHIRBaseModel):
+            # Single instance: check if it's a parent class
+            is_parent_instance = type(value) != base_type and issubclass(
+                base_type, type(value)
+            )
+        elif isinstance(value, list):
+            # List: check if any items are parent class instances
+            is_parent_instance = any(
+                isinstance(item, FHIRBaseModel)
+                and type(item) != base_type
+                and issubclass(base_type, type(item))
+                for item in value
+            )
+
+        if not (is_abstract or is_parent_instance):
+            return value
+
+        # Create a unique key for this deserialization context
+        context_key = (cls, field_name, base_type)
+        stack = _get_polymorphic_deserialization_stack()
+
+        # Check if we're already processing this context to prevent recursion
+        if context_key in stack:
+            return value
+
+        # Add to stack and process
+        stack.add(context_key)
+        try:
+            result = cls._deserialize_polymorphically(value, base_type)
+            return result
+        except Exception:
+            return value
+        finally:
+            # Always remove from stack when done
+            stack.discard(context_key)
 
     @model_serializer(mode="wrap")
     def _serialize_polymorphic_fields(
@@ -787,10 +812,28 @@ class FHIRBaseModel(BaseModel, FHIRPathMixin):
 
     @classmethod
     def _deserialize_polymorphically(cls, value: Any, base_type: Type) -> Any:
-        """Deserialize a value using the best matching subclass."""
+        """Deserialize a value using the best matching subclass.
+
+        Handles:
+        - Lists of items to deserialize recursively
+        - FHIR instances (parent class instances) by converting to dict for re-validation
+        - Dictionaries (potential FHIR objects) by trying subclasses
+        """
         # Handle lists
         if isinstance(value, list):
             return [cls._deserialize_polymorphically(item, base_type) for item in value]
+
+        # Handle FHIRBaseModel instances (e.g., parent class instances for profile fields)
+        if isinstance(value, FHIRBaseModel):
+            # If the value is already an instance of the target type or a subclass, return as-is
+            if isinstance(value, base_type):
+                return value
+
+            # Convert the parent instance to a dictionary for re-validation against the target type
+            # This allows Pydantic to validate and convert it properly
+            value_dict = value.model_dump()
+            # Recursively deserialize the dictionary
+            return cls._deserialize_polymorphically(value_dict, base_type)
 
         # Handle dictionaries (potential FHIR objects)
         if isinstance(value, dict):

--- a/test/test_fhir_resources_polymorphism.py
+++ b/test/test_fhir_resources_polymorphism.py
@@ -225,6 +225,78 @@ class TestPolymorphicDeserialization:
             assert "Extra inputs are not permitted" in str(e)
         MockModel._enable_polymorphic_deserialization = original_setting
 
+    def test_profile_accepts_parent_class_instance(self):
+        """Test that profile models accept instances of their parent classes.
+
+        This tests the scenario where a profile extends a base datatype (e.g., ExamplePatientName
+        extending HumanName), and we want to pass an instance of the parent class.
+        """
+
+        # Create mock models simulating a profile scenario
+        class BaseName(FHIRBaseModel):
+            _kind = "complex-type"
+            _abstract = True
+            _type = "BaseName"
+            given: Optional[List[str]] = None
+            family: Optional[str] = None
+
+        class ProfileName(BaseName):
+            _kind = "complex-type"
+            _abstract = False
+            _type = "ProfileName"
+            # Profile adds additional constraints or fields
+
+        class Patient(FHIRBaseModel):
+            _kind = "resource"
+            _abstract = True
+            _type = "Patient"
+            id: Optional[str] = None
+            name: Optional[List[ProfileName]] = None
+
+        # Test 1: Accepting dict should work
+        instance_dict = Patient(name=[{"given": ["John"], "family": "Doe"}])  # type: ignore
+        assert instance_dict.name
+        assert len(instance_dict.name) == 1
+        assert instance_dict.name[0].given == ["John"]
+        assert instance_dict.name[0].family == "Doe"
+
+        # Test 2: Accepting parent class instance should also work
+        base_name_instance = BaseName(given=["Jane"], family="Smith")
+        instance_obj = Patient(name=[base_name_instance])  # type: ignore
+        assert instance_obj.name
+        assert len(instance_obj.name) == 1
+        assert isinstance(instance_obj.name[0], (BaseName, ProfileName))
+        assert instance_obj.name[0].given == ["Jane"]
+        assert instance_obj.name[0].family == "Smith"
+
+    def test_profile_accepts_parent_in_direct_assignment(self):
+        """Test that profile models accept parent class instances in direct assignment."""
+
+        # Create mock models
+        class BaseDataType(FHIRBaseModel):
+            _kind = "complex-type"
+            _abstract = True
+            _type = "BaseDataType"
+            value: Optional[str] = None
+
+        class ProfileDataType(BaseDataType):
+            _kind = "complex-type"
+            _abstract = False
+            _type = "ProfileDataType"
+
+        class Container(FHIRBaseModel):
+            _kind = "resource"
+            _abstract = True
+            _type = "Container"
+            data: ProfileDataType
+
+        # Create and assign a parent class instance
+        base_instance = BaseDataType(value="test_value")
+        container = Container(data=base_instance)  # type: ignore
+
+        # Should accept the parent instance
+        assert container.data.value == "test_value"
+
 
 class TestPolymorphicUtilityMethods:
     """Test utility methods used in polymorphic functionality."""

--- a/test/test_fhir_resources_regression.py
+++ b/test/test_fhir_resources_regression.py
@@ -476,3 +476,54 @@ def test_regression_issue_263(factory, generator):
     assert (
         source_code.count("class ") == 3
     ), f"Expected exactly 3 classes to be generated, got {source_code.count('class')} \n Generated code:\n{source_code}"
+
+
+def test_regression_issue_262():
+    from pydantic import Field, model_validator
+    from typing import Optional, List
+    from fhircraft.fhir.resources.datatypes.R5.core import Patient
+    from typing import List, Optional
+    from fhircraft.fhir.resources.datatypes.R5.complex import HumanName, Meta
+    from fhircraft.fhir.resources.datatypes.primitives import String
+    from fhircraft.fhir.resources.validators import validate_element_constraint
+
+    class ExamplePatientName(HumanName):
+        family: Optional[String] = Field(
+            description="(USCDI) Family name (often called \u0027Surname\u0027)",
+            default=None,
+        )
+
+    class ExamplePatient(Patient):
+
+        _canonical_url = "http://example.org/fhir/StructureDefinition/example"
+
+        meta: Optional[Meta] = Field(
+            title="Meta",
+            description="Metadata about the resource.",
+            default_factory=lambda: Meta(
+                profile=["http://example.org/fhir/StructureDefinition/example"]
+            ),
+        )
+        name: Optional[List[ExamplePatientName]] = Field(
+            description="(USCDI) A name associated with the patient",
+            default=None,
+        )
+
+        @model_validator(mode="after")
+        def FHIR_us_core_6_constraint_validator(self):
+            return validate_element_constraint(
+                self,
+                elements=["name"],
+                expression="(family.exists() or given.exists()) xor extension.where(url='http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()",
+                human="At least name.given and/or name.family are present or, if neither is available, the Data Absent Reason Extension is present.",
+                key="us-core-6",
+                severity="error",
+            )
+
+    instance = ExamplePatient(
+        name=[HumanName(given=["John"], family="Doe")]  # type: ignore
+    )
+
+    assert isinstance(instance, ExamplePatient)
+    assert instance.name
+    assert instance.name[0].given == ["John"]


### PR DESCRIPTION
This PR fixes polymorphic deserialization to accept parent class instances in profile models, ensuring that all valid parent instances are structurally valid for derived profile classes.

### Fixed

- Enabled polymorphic deserialization for profile models to accept instances of their parent classes, matching the behavior of dictionary deserialization. Profile fields now properly validate and adopt parent class instances while preserving all data. Fixes #262