### PR TITLE
Ensure specialized `BackboneElement` subclasses are used in differential mode

### DIFF
--- a/fhircraft/fhir/resources/factory.py
+++ b/fhircraft/fhir/resources/factory.py
@@ -1924,6 +1924,23 @@ class ResourceFactory:
                     field_subfields["extension"] = self._construct_Pydantic_field(
                         extension_type, extension_min_card, extension_max_card
                     )
+                # If in differential mode, instead of BackboneElement, use the base model's backbone model
+                if (
+                    self.Config.construction_mode == ConstructionMode.DIFFERENTIAL
+                    and base
+                    and issubclass(base, BaseModel)
+                    and name in base.model_fields
+                ):
+                    from typing import get_args as get_type_args
+
+                    _field_type = get_type_args(base.model_fields[name].annotation)[0]
+                    while _field_type and not (
+                        inspect.isclass(_field_type)
+                        and issubclass(_field_type, BaseModel)
+                    ):
+                        _field_type = get_type_args(_field_type)[0]
+                    field_type = _field_type
+                # Construct the model for the element with children (backbone element)
                 field_type = self._construct_model_with_properties(
                     backbone_model_name,
                     fields=field_subfields,

--- a/test/test_fhir_resources_regression.py
+++ b/test/test_fhir_resources_regression.py
@@ -1036,3 +1036,65 @@ def test_regression_issue_278(factory, generator):
     assert (
         source_code.count("class ") == 2
     ), f"Expected exactly 2 classes to be generated, got {source_code.count('class')} \n Generated code:\n{source_code}"
+
+
+def test_regression_issue_277(factory, generator):
+
+    structure_definition = {
+        "resourceType": "StructureDefinition",
+        "id": "my-adverse-event",
+        "url": "http://example.org/fhir/StructureDefinition/my-adverse-event",
+        "name": "MyAdverseEvent",
+        "title": "Adverse Event Profile",
+        "status": "active",
+        "description": "A description",
+        "fhirVersion": "4.0.1",
+        "kind": "resource",
+        "abstract": False,
+        "type": "AdverseEvent",
+        "baseDefinition": "http://hl7.org/fhir/StructureDefinition/AdverseEvent",
+        "derivation": "constraint",
+        "differential": {
+            "element": [
+                {
+                    "id": "AdverseEvent",
+                    "path": "AdverseEvent",
+                    "short": "Adverse Event Profile",
+                    "definition": "A description",
+                    "min": 0,
+                    "max": "*",
+                },
+                {
+                    "id": "AdverseEvent.suspectEntity",
+                    "path": "AdverseEvent.suspectEntity",
+                },
+                {
+                    "id": "AdverseEvent.suspectEntity.instance",
+                    "path": "AdverseEvent.suspectEntity.instance",
+                    "type": [
+                        {
+                            "code": "Reference",
+                            "targetProfile": [
+                                "http://example.org/fhir/StructureDefinition/example-medication",
+                            ],
+                        }
+                    ],
+                },
+            ]
+        },
+    }
+
+    model = factory.construct_resource_model(
+        structure_definition=structure_definition, mode="differential"
+    )
+
+    source_code = generator.generate_resource_model_code(model)
+
+    expected_code = """    
+    class MyAdverseEventSuspectEntity(AdverseEventSuspectEntity):
+    """
+    assertBlockInCode(source_code, expected_code.strip())
+
+    assert (
+        source_code.count("class ") == 2
+    ), f"Expected exactly 2 classes to be generated, got {source_code.count('class')} \n Generated code:\n{source_code}"


### PR DESCRIPTION
This PR ensures that when constructing differential mode profiles with backbone elements, specialized BackboneElement subclasses from the base model are used as bases instead of generic BackboneElement. This improves type correctness and allows proper inheritance of backbone element structure in generated profile models.


### Fixed

- Ensured that when constructing differential mode profiles, specialized BackboneElement subclasses from the base model are used as bases instead of generic BackboneElement, allowing proper inheritance of backbone element structure. Fixes #277