### PR TITLE
Add Google site verification meta tag to mkdocs configuration

### DIFF
--- a/docs/.overrides/main.html
+++ b/docs/.overrides/main.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 
+{% block extrahead %}
+  {{ super() }}
+  <meta name="google-site-verification" content="WxBOYzoPwXEpbBzRPFEWMfnkd3QZMNjCuVtsikkDhgU" />
+{% endblock %}
+
 {% block announce %}
   <span class="twemoji">
     {% include ".icons/material/tools.svg" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,9 +54,6 @@ extra:
       link: https://github.com/luisfabib/fhircraft
     - icon: fontawesome/brands/python 
       link: https://pypi.org/project/fhircraft/
-  meta:
-    - name: google-site-verification
-      content: WxBOYzoPwXEpbBzRPFEWMfnkd3QZMNjCuVtsikkDhgU
 
 markdown_extensions:
   - attr_list


### PR DESCRIPTION
This pull request introduces a small configuration update to the `mkdocs.yml` file. The main change is the addition of a meta tag for Google site verification.

### Changed
  * Added a `google-site-verification` meta tag to the `extra:` section in `mkdocs.yml` to enable site ownership verification with Google.