### PR TITLE
Add pull request template for consistent contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+### Information
+
+**Delete this section in the final version**
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Summarize all changes in your PR in changelog format under the corresponding sections (added, changed, fixed, removed). Delete any section that does not apply to your changes
+
+Types of changes
+    * `Added` for new features.
+    * `Changed` for changes in existing functionality.
+    * `Deprecated` for soon-to-be removed features.
+    * `Removed` for now removed features.
+    * `Fixed` for any bug fixes.
+    * `Security` in case of vulnerabilities.
+
+### Added
+
+### Changed 
+
+### Fixes
+
+### Removed
+
+-----
+
+### Testing
+
+Please describe the tests that you added/modified to verify your changes.
+
+
+
+### Checklist:
+
+- [ ] Self-review of the new code performed
+- [ ] Commented hard-to-understand areas
+- [ ] Made corresponding changes to the documentation
+- [ ] New changes generate no new warnings
+- [ ] Added tests that prove a fix is effective or that a feature works


### PR DESCRIPTION
This pull request adds a new pull request template to the repository to standardize and improve the quality of PR descriptions. The template guides contributors to summarize their changes, categorize them, and provide testing details, which will help reviewers understand and verify changes more efficiently.

### Added

* Added a new `.github/pull_request_template.md` file with sections for change summary, changelog categorization, testing instructions, and a checklist for contributors.