### PR TITLE
Support the FHIRPath `System` type namespace 

### DIFF
--- a/fhircraft/fhir/path/engine/core.py
+++ b/fhircraft/fhir/path/engine/core.py
@@ -1026,12 +1026,43 @@ class TypeSpecifier(FHIRPath):
                     UserWarning,
                 )
                 release = "R4"
-            type = get_fhir_type(self.specifier, release=release)
+            resolved_type = get_fhir_type(self.specifier, release)
+        elif namespace == "System":
+            from fhircraft.fhir.path.engine.literals import (
+                Date,
+                DateTime,
+                Quantity,
+                Time,
+            )
+
+            match self.specifier:
+                case "String":
+                    resolved_type = str
+                case "Boolean":
+                    resolved_type = bool
+                case "Integer":
+                    resolved_type = int
+                case "Long":
+                    resolved_type = int
+                case "Decimal":
+                    resolved_type = float
+                case "Date":
+                    resolved_type = Date
+                case "DateTime":
+                    resolved_type = DateTime
+                case "Time":
+                    resolved_type = Time
+                case "Quantity":
+                    resolved_type = Quantity
+                case _:
+                    raise NameError(
+                        f"Unknown type specifier '{self.specifier}' in System namespace"
+                    )
         else:
             raise NameError(
                 f"Unknown namespace '{self.namespace}' for type specifier '{self.specifier}'"
             )
-        return [FHIRPathCollectionItem(value=type)]
+        return [FHIRPathCollectionItem(value=resolved_type)]
 
     def __str__(self):
         return (

--- a/fhircraft/fhir/path/engine/types.py
+++ b/fhircraft/fhir/path/engine/types.py
@@ -55,22 +55,30 @@ class FHIRTypesOperator(FHIRPath):
         from fhircraft.fhir.resources.datatypes import utils as type_utils
 
         type_: type = self.type_specifier.evaluate([], environment, create)[0].value
-        # Handle the FHIRPath literal types as special cases
-        if isinstance(value, fhirpath_literals.Quantity):
-            return type_.__name__ == "Quantity"
-        elif isinstance(value, fhirpath_literals.Date):
-            return type_.__name__ == "Date"
-        elif isinstance(value, fhirpath_literals.DateTime):
-            return type_.__name__ == "DateTime"
-        elif isinstance(value, fhirpath_literals.Time):
-            return type_.__name__ == "Time"
+        namespace = self.type_specifier.namespace or "FHIR"
+        if namespace == "FHIR":
+            # Handle the FHIRPath literal types as special cases
+            if isinstance(value, fhirpath_literals.Quantity):
+                return type_.__name__ == "Quantity"
+            elif isinstance(value, fhirpath_literals.Date):
+                return type_.__name__ == "Date"
+            elif isinstance(value, fhirpath_literals.DateTime):
+                return type_.__name__ == "DateTime"
+            elif isinstance(value, fhirpath_literals.Time):
+                return type_.__name__ == "Time"
+            else:
+                try:
+                    return type_utils.is_fhir_primitive_type(value, type_)
+                except type_utils.FHIRTypeError:
+                    return type_utils.is_fhir_complex_type(
+                        value, type_
+                    ) or type_utils.is_fhir_resource_type(value, type_)
+        elif namespace == "System":
+            return isinstance(value, type_)
         else:
-            try:
-                return type_utils.is_fhir_primitive_type(value, type_)
-            except type_utils.FHIRTypeError:
-                return type_utils.is_fhir_complex_type(
-                    value, type_
-                ) or type_utils.is_fhir_resource_type(value, type_)
+            raise FHIRPathRuntimeError(
+                f"Invalid type specifier namespace '{self.type_specifier.namespace}' in operator {self.__str__()}. Expected 'FHIR' or 'System'."
+            )
 
     def __str__(self):
         raise NotImplementedError("Subclasses must implement __str__ method.")

--- a/test/test_fhir_path_engine_types.py
+++ b/test/test_fhir_path_engine_types.py
@@ -15,41 +15,67 @@ env = {"%fhirRelease": "R4"}
 # -------------
 
 test_cases = (
-    ("ABC", "string", True),
-    ("123", "string", True),
-    ("", "string", True),
-    (123, "string", False),
-    # Integer type checking
-    (12, "integer", True),
-    ("12", "integer", True),
-    (-12, "integer", True),
-    # UnsignedInt type checking
-    (12, "unsignedInt", True),
-    ("12", "unsignedInt", True),
-    (0, "unsignedInt", True),
-    (-12, "unsignedInt", False),
-    ("-12", "unsignedInt", False),
-    # PositiveInt type checking
-    (12, "positiveInt", True),
-    ("12", "positiveInt", True),
-    (0, "positiveInt", False),
-    (-12, "positiveInt", False),
-    ("-12", "positiveInt", False),
-    # Decimal type checking
-    (23, "decimal", True),
-    (23.32, "decimal", True),
-    ("23.32", "decimal", True),
-    ("23", "decimal", True),
-    # Boolean type checking
-    (True, "boolean", True),
-    ("true", "boolean", True),
-    (False, "boolean", True),
-    ("false", "boolean", True),
-    ("invalid", "boolean", False),
-    (Date("@2024"), "date", True),
-    (Quantity(12, "g"), "Quantity", True),
-    (Practitioner(id="example"), "Practitioner", True),
-    (Observation(id="example"), "Observation", True),
+    # FHIR String type checking
+    ("ABC", "FHIR.string", True),
+    ("123", "FHIR.string", True),
+    ("", "FHIR.string", True),
+    (123, "FHIR.string", False),
+    # FHIR Integer type checking
+    (12, "FHIR.integer", True),
+    (-12, "FHIR.integer", True),
+    (0, "FHIR.integer", True),
+    ("12", "FHIR.integer", True),
+    ("-12", "FHIR.integer", True),
+    # FHIR UnsignedInt type checking
+    (12, "FHIR.unsignedInt", True),
+    ("12", "FHIR.unsignedInt", True),
+    (0, "FHIR.unsignedInt", True),
+    (-12, "FHIR.unsignedInt", False),
+    ("-12", "FHIR.unsignedInt", False),
+    # FHIR PositiveInt type checking
+    (12, "FHIR.positiveInt", True),
+    ("12", "FHIR.positiveInt", True),
+    (0, "FHIR.positiveInt", False),
+    (-12, "FHIR.positiveInt", False),
+    ("-12", "FHIR.positiveInt", False),
+    # System Integer type checking
+    (12, "System.Integer", True),
+    ("12", "System.Integer", False),
+    (0, "System.Integer", True),
+    (-12, "System.Integer", True),
+    ("-12", "System.Integer", False),
+    # FHIR Decimal type checking
+    (23, "FHIR.decimal", True),
+    (23.32, "FHIR.decimal", True),
+    ("23.32", "FHIR.decimal", True),
+    ("23", "FHIR.decimal", True),
+    # System Decimal type checking
+    (23, "System.Decimal", False),
+    (23.32, "System.Decimal", True),
+    ("23.32", "System.Decimal", False),
+    ("23", "System.Decimal", False),
+    # FHIR Boolean type checking
+    (True, "FHIR.boolean", True),
+    ("true", "FHIR.boolean", True),
+    (False, "FHIR.boolean", True),
+    ("false", "FHIR.boolean", True),
+    ("invalid", "FHIR.boolean", False),
+    # System Boolean type checking
+    (True, "System.Boolean", True),
+    ("true", "System.Boolean", False),
+    (False, "System.Boolean", True),
+    ("false", "System.Boolean", False),
+    ("invalid", "System.Boolean", False),
+    # FHIR Complex type checking
+    (Date("@2024"), "FHIR.date", True),
+    (Quantity(12, "g"), "FHIR.Quantity", True),
+    (Practitioner(id="example"), "FHIR.Practitioner", True),
+    (Observation(id="example"), "FHIR.Observation", True),
+    # System Complex type checking
+    (Date("@2024"), "System.Date", True),
+    (Quantity(12, "g"), "System.Quantity", True),
+    (Practitioner(id="example"), "System.Quantity", False),
+    (Observation(id="example"), "System.Quantity", False),
 )
 
 


### PR DESCRIPTION
This PR adds support for the `System` namespace in FHIRPath type specifier expressions (e.g. `System.String`, `System.Integer`), enabling native Python type resolution and strict `isinstance`-based type checking alongside the existing `FHIR` namespace.

### Added
- Added `System` namespace resolution to `TypeSpecifier`, mapping all FHIRPath System types (`String`, `Boolean`, `Integer`, `Long`, `Decimal`, `Date`, `DateTime`, `Time`, `Quantity`) to their corresponding types. Closes #167
- Added support for the `Is`, `LegacyIs`, `As`, `LegacyAs` FHIRPath functions to check values against the `System` type namespace.