### PR TITLE
Ensure that FHIRPath types are built as python native types rather than primitive classes

### DIFF
--- a/fhircraft/fhir/resources/factory/builders/base.py
+++ b/fhircraft/fhir/resources/factory/builders/base.py
@@ -65,10 +65,20 @@ CLASS_RESERVED_KEYWORDS: frozenset[str] = frozenset(
     {"property", "classmethod", "field_validator", "model_validator"}
 )
 FHIR_SD_PREFIX = "http://hl7.org/fhir/StructureDefinition/"
-FHIRPATH_TYPE_PREFIX = "http://hl7.org/fhirpath/System."
+FHIRPATH_TYPE_PREFIX = "http://hl7.org/fhirpath/"
 FHIR_TYPE_EXT_URL = (
     "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type"
 )
+FHIRPATH_TYPE_MAPPING: dict[str, type] = {
+    "System.String": str,
+    "System.Boolean": bool,
+    "System.Integer": int,
+    "System.Decimal": float,
+    "System.Date": str,
+    "System.DateTime": str,
+    "System.Time": str,
+    "System.Quantity": str,
+}
 
 _Unset: Any = PydanticUndefined
 
@@ -401,28 +411,18 @@ class Builder(ABC):
         type_code = str(type.code)
         is_fhirpath_system_type = type_code.startswith(FHIRPATH_TYPE_PREFIX)
 
-        # Handle the special case of FHIRPath system types, which are identified by a URL but do not have a profile and are not valid FHIR type names
-        if is_fhirpath_system_type:
-            fhir_type_extension = next(
-                (ext for ext in type.extension or [] if ext.url == FHIR_TYPE_EXT_URL),
-                None,
-            )
-            if not fhir_type_extension or not fhir_type_extension.valueUrl:
-                # Fallback to the raw code if no profile is provided
-                type_code = type_code.removeprefix(FHIRPATH_TYPE_PREFIX)
-            else:
-                # For FHIRPath system types, the profile URL contains the actual FHIR type name
-                type_code = fhir_type_extension.valueUrl
-
         # This is a rare case, only logical models and FHIRPath system types should use this
         if type_code.startswith(FHIR_SD_PREFIX):
             type_code = type_code.removeprefix(FHIR_SD_PREFIX)
-
-        type_code = capitalize(str(type_code))
+            type_code = capitalize(str(type_code))
 
         # If a profile is specified and it's not a FHIRPath system type, resolve and build the profile to get the actual type to use
         if type.profile and not is_fhirpath_system_type:
             fhir_type = self.context.factory.build(canonical_url=str(type.profile[0]))
+        elif is_fhirpath_system_type:
+            fhir_type = FHIRPATH_TYPE_MAPPING[
+                type_code.removeprefix(FHIRPATH_TYPE_PREFIX)
+            ]
         else:
             # Get the Fhircraft type
             fhir_type = get_fhir_type(type_code, fhir_release)
@@ -430,7 +430,7 @@ class Builder(ABC):
         kind = (
             fhir_type._kind
             if inspect.isclass(fhir_type) and issubclass(fhir_type, FHIRBaseModel)
-            else "primitive"
+            else "primitive-type"
         )
         return TypeInformation(
             type=fhir_type,

--- a/test/test_fhir_resources_factory.py
+++ b/test/test_fhir_resources_factory.py
@@ -1182,7 +1182,7 @@ def test_factory__construct_diff_min_cardinality(factory: FHIRModelFactory):
     element = mock_resource.model_fields.get("id")
     assert element is not None, "Profiled element field not found in model fields"
     assert (
-        element.annotation == Optional[primitives.String]
+        element.annotation == Optional[str]
     ), "Profiled element field does not have correct type annotation"
 
     # Assert metadata

--- a/test/test_fhir_resources_factory_builders_base.py
+++ b/test/test_fhir_resources_factory_builders_base.py
@@ -274,13 +274,13 @@ def test_resolve_type__primitive_absolute_url(builder: Builder, code, expected):
 
 
 FHIRPATH_CODES = [
-    ("System.String", primitive.String),
-    ("System.Integer", primitive.Integer),
-    ("System.Boolean", primitive.Boolean),
-    ("System.Decimal", primitive.Decimal),
-    ("System.Date", primitive.Date),
-    ("System.DateTime", primitive.DateTime),
-    ("System.Time", primitive.Time),
+    ("System.String", str),
+    ("System.Integer", int),
+    ("System.Boolean", bool),
+    ("System.Decimal", float),
+    ("System.Date", str),
+    ("System.DateTime", str),
+    ("System.Time", str),
 ]
 
 
@@ -290,36 +290,6 @@ FHIRPATH_CODES = [
 )
 def test_resolve_type__fhirpath_without_profile(builder: Builder, code, expected):
     info = builder.resolve_type(make_type(code=f"http://hl7.org/fhirpath/{code}"))
-    assert info.kind == "primitive-type"
-    assert info.type is expected
-
-
-@pytest.mark.parametrize(
-    "code, fhir_type, expected",
-    [
-        ("System.String", "Uri", primitive.Uri),
-        ("System.String", "Code", primitive.Code),
-        ("System.String", "Canonical", primitive.Canonical),
-        ("System.Integer", "PositiveInt", primitive.PositiveInt),
-        ("System.Boolean", "Boolean", primitive.Boolean),
-        ("System.Decimal", "Decimal", primitive.Decimal),
-        ("System.Date", "Date", primitive.Date),
-        ("System.DateTime", "DateTime", primitive.DateTime),
-        ("System.Time", "Time", primitive.Time),
-    ],
-)
-def test_resolve_type__fhirpath_with_extension(
-    builder: Builder, code, fhir_type, expected
-):
-    type_extension = MagicMock()
-    type_extension.url = FHIR_TYPE_EXT_URL
-    type_extension.valueUrl = fhir_type
-    info = builder.resolve_type(
-        make_type(
-            code=f"http://hl7.org/fhirpath/{code}",
-            extension=[type_extension],
-        )
-    )
     assert info.kind == "primitive-type"
     assert info.type is expected
 


### PR DESCRIPTION
### Fixed

* Ensured that elements (e.g. `Extension.url`) defined with FHIRPath-typed elements (which should not have extensions or ids) are not built using the new primitive classes (that can hold extensions and ids) but rather using Python native types.
