### PR TITLE
Use type aliases for primitive type annotations in generated code

### DIFF
--- a/fhircraft/fhir/resources/generator.py
+++ b/fhircraft/fhir/resources/generator.py
@@ -37,6 +37,7 @@ LEFT_TO_RIGHT_SIMPLE = "Field(union_mode='left_to_right')"
 class CodeGenerator:
 
     import_statements: Dict[str, List[str]]
+    alias_import_statements: Dict[str, str]
     template: Template
     data: Dict
 
@@ -54,10 +55,61 @@ class CodeGenerator:
         Clears the import statements and data dictionaries.
         """
         self.import_statements = defaultdict(list)
+        self.alias_import_statements = {}
         self.data = {}
         self._processing_models = (
             set()
         )  # Track models being processed to prevent infinite recursion
+
+    def _track_module_alias_import(self, module: str, alias: str) -> bool:
+        """Track an aliased module import (e.g. `import x.y as z`)."""
+        existing_module_for_alias = next(
+            (m for m, a in self.alias_import_statements.items() if a == alias), None
+        )
+        if existing_module_for_alias and existing_module_for_alias != module:
+            return False
+        self.alias_import_statements[module] = alias
+        return True
+
+    def _get_primitive_package_module(self, module: str) -> Optional[str]:
+        """Return the `...primitive` package module from a primitive submodule path."""
+        parts = module.split(".")
+        try:
+            primitive_index = parts.index("primitive")
+        except ValueError:
+            return None
+        if primitive_index < 1:
+            return None
+        return ".".join(parts[: primitive_index + 1])
+
+    def _resolve_primitive_class_alias(
+        self, annotation: Any
+    ) -> Optional[Tuple[str, str]]:
+        """Resolve primitive classes (e.g. String) to their module alias (e.g. string)."""
+        if not isinstance(annotation, type):
+            return None
+        module_name = getattr(annotation, "__module__", "")
+        if ".primitive." not in module_name:
+            return None
+        module = sys.modules.get(module_name)
+        if module is None:
+            return None
+
+        for name, val in vars(module).items():
+            if name.startswith("_"):
+                continue
+            if get_origin(val) is not Annotated:
+                continue
+            metadata = getattr(val, "__metadata__", ())
+            for meta in metadata:
+                func = getattr(meta, "func", None)
+                klass = getattr(func, "__self__", None)
+                if klass is annotation:
+                    primitive_module = self._get_primitive_package_module(module_name)
+                    if primitive_module is None:
+                        return None
+                    return primitive_module, name
+        return None
 
     def _extract_default_factory_code(self, default_factory: Any) -> str:
         """
@@ -177,6 +229,22 @@ class CodeGenerator:
         Raises:
             ValueError: If the object does not belong to a module.
         """
+        # Primitive aliases are emitted as `fhir.<alias>` and use a module alias import.
+        resolved_primitive = self._resolve_annotated_primitive(annotation)
+        if resolved_primitive is not None:
+            module, _ = resolved_primitive
+            primitive_module = self._get_primitive_package_module(module)
+            if primitive_module:
+                self._track_module_alias_import(primitive_module, "fhir")
+            return
+
+        # Primitive classes are also emitted as `fhir.<alias>`.
+        resolved_primitive_class = self._resolve_primitive_class_alias(annotation)
+        if resolved_primitive_class is not None:
+            primitive_module, _ = resolved_primitive_class
+            self._track_module_alias_import(primitive_module, "fhir")
+            return
+
         # Check if this is a generic type and handle typing imports
         origin = get_origin(annotation)
         if origin is not None:
@@ -299,12 +367,23 @@ class CodeGenerator:
         if annotation is type(None):
             return "None"
 
+        # Primitive class (e.g. String, Integer) -> fhir.string / fhir.integer
+        resolved_class = self._resolve_primitive_class_alias(annotation)
+        if resolved_class is not None:
+            primitive_module, alias_name = resolved_class
+            if self._track_module_alias_import(primitive_module, "fhir"):
+                return f"fhir.{alias_name}"
+            return alias_name
+
         # Direct Annotated primitive alias (e.g. string, boolean, …)
         resolved = self._resolve_annotated_primitive(annotation)
         if resolved is not None:
             module, name = resolved
-            if name not in self.import_statements[module]:
-                self.import_statements[module].append(name)
+            primitive_module = self._get_primitive_package_module(module)
+            if primitive_module and self._track_module_alias_import(
+                primitive_module, "fhir"
+            ):
+                return f"fhir.{name}"
             return name
 
         origin = get_origin(annotation)
@@ -318,13 +397,16 @@ class CodeGenerator:
         if not args:
             return repr(annotation)
 
-        # Fast path: if no arg (recursively) contains an Annotated, use repr as-is
-        def _has_annotated(ann: Any) -> bool:
+        # Fast path: if no arg (recursively) contains an Annotated or a primitive
+        # class (e.g. String, Integer), use repr as-is; otherwise recurse.
+        def _has_annotated_or_primitive(ann: Any) -> bool:
             if get_origin(ann) is Annotated:
                 return True
-            return any(_has_annotated(a) for a in get_args(ann))
+            if self._resolve_primitive_class_alias(ann) is not None:
+                return True
+            return any(_has_annotated_or_primitive(a) for a in get_args(ann))
 
-        if not any(_has_annotated(a) for a in args):
+        if not any(_has_annotated_or_primitive(a) for a in args):
             return repr(annotation)
 
         # Union / Optional (both "X | Y" UnionType and typing.Union[X, Y])
@@ -354,6 +436,14 @@ class CodeGenerator:
             origin, "_name", None
         )
         if origin_name:
+            # Map builtin lowercase names to their typing equivalents
+            typing_name_map = {
+                "list": "List",
+                "dict": "Dict",
+                "tuple": "Tuple",
+                "set": "Set",
+            }
+            origin_name = typing_name_map.get(origin_name, origin_name)
             if origin_name in ("List", "Dict", "Set", "Tuple", "FrozenSet"):
                 if origin_name not in self.import_statements["typing"]:
                     self.import_statements["typing"].append(origin_name)
@@ -761,6 +851,7 @@ class CodeGenerator:
         source_code = self.template.render(
             data=self.data,
             imports=grouped_imports,
+            alias_imports=self.alias_import_statements,
             include_validators=include_validators,
             metadata={
                 "version": version("fhircraft"),

--- a/fhircraft/fhir/resources/resource_template.py.j2
+++ b/fhircraft/fhir/resources/resource_template.py.j2
@@ -3,7 +3,10 @@
 {% for module, objects in imports.items() -%} 
 from {{ module }} import {{ objects|join(', ') }}
 {% endfor -%}
-{% if imports %}
+{% for module, alias in alias_imports.items() -%}
+import {{ module }} as {{ alias }}
+{% endfor -%}
+{% if imports or alias_imports %}
 {% endif -%}
 NoneType = type(None)
 

--- a/test/test_fhir_resources_generator.py
+++ b/test/test_fhir_resources_generator.py
@@ -58,10 +58,10 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         # Expected code block
         expected_class = """
         class SimpleModel(BaseModel):
-            id: String = Field(
+            id: fhir.string = Field(
                 description="The unique identifier.",
             )
-            value: Integer = Field(
+            value: fhir.integer = Field(
                 description="A value.",
                 default=42,
             )
@@ -80,7 +80,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         # Expected code block
         expected_block = """
         class ModelWithAlias(BaseModel):
-            name: String = Field(
+            name: fhir.string = Field(
                 description="The person name.",
                 alias="fullName",
             )
@@ -99,7 +99,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         # Expected code block
         expected_block = """
         class ModelWithOptional(BaseModel):
-            description: Optional[String] = Field(
+            description: Optional[fhir.string] = Field(
                 description="Optional description.",
                 default=None,
             )
@@ -118,7 +118,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         # Expected code block
         expected_block = """
         class ModelWithList(BaseModel):
-            items: List[Integer] = Field(
+            items: List[fhir.integer] = Field(
                 description="A list of items.",
                 default_factory=list,
             )
@@ -303,7 +303,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         )
         expected_block = """
         class ModelWithTitle(BaseModel):
-            code: String = Field(
+            code: fhir.string = Field(
                 title="Code Field",
                 description="A code with title.",
             )
@@ -411,7 +411,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
             """
             This is a model with a docstring.
             """
-            value: string = Field(
+            value: fhir.string = Field(
                 description="A string field.",
             )
 
@@ -457,13 +457,14 @@ class TestJinjaTemplateRendering(unittest.TestCase):
     def test_model_with_multiple_inheritance_slice(self):
         """Test that slice models with multiple inheritance generate correctly."""
         from fhircraft.fhir.resources.datatypes.R4B.complex.extension import Extension
+        from fhircraft.fhir.resources.datatypes.R4B.primitive import string
         from fhircraft.fhir.resources.base import FHIRSliceModel
 
         # Create a model with multiple inheritance (Extension + FHIRSliceModel)
         model = _create_model(
             "ExtensionSlice",
             url=(str, Field(description="Extension URL")),
-            valueString=(str, Field(description="A string value")),
+            valueString=(string, Field(description="A string value")),
             __base__=(Extension, FHIRSliceModel),
         )
         assert issubclass(model, FHIRSliceModel)
@@ -478,7 +479,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
             url: str = Field(
                 description="Extension URL",
             )
-            valueString: str = Field(
+            valueString: fhir.string = Field(
                 description="A string value",
             )
         """
@@ -488,8 +489,8 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         # Create model with a property
         model = create_model(
             "ModelWithProperty",
-            valueString=(primitives.String, Field(description="A value.")),
-            valueInteger=(primitives.Integer, Field(description="A value.")),
+            valueString=(primitives.string, Field(description="A value.")),
+            valueInteger=(primitives.integer, Field(description="A value.")),
         )
         # Add a property method
         setattr(
@@ -502,10 +503,10 @@ class TestJinjaTemplateRendering(unittest.TestCase):
 
         expected_block = """
         class ModelWithProperty(BaseModel):
-            valueString: String = Field(
+            valueString: fhir.string = Field(
                 description="A value.",
             )
-            valueInteger: Integer = Field(
+            valueInteger: fhir.integer = Field(
                 description="A value.",
             )
 
@@ -850,7 +851,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         # The property SHOULD be in the derived model code since it's different
         expected_block = """
         class DerivedModelWithOverriddenProperty(BaseModelWithOriginalProperty):
-            valueInteger: Integer = Field(
+            valueInteger: fhir.integer = Field(
                 description="Another value.",
             )
 
@@ -867,14 +868,14 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         # Create a base model without any property
         base_model = _create_model(
             "BaseModelWithoutProperty",
-            valueString=(primitives.String, Field(description="A value.")),
+            valueString=(primitives.string, Field(description="A value.")),
             __base__=(BaseModel,),
         )
 
         # Create a derived model that adds a new property
         derived_model = _create_model(
             "DerivedModelWithNewProperty",
-            valueInteger=(primitives.Integer, Field(description="Another value.")),
+            valueInteger=(primitives.integer, Field(description="Another value.")),
             __base__=(base_model,),
         )
         # Add a new property that doesn't exist in base
@@ -890,7 +891,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         # The new property SHOULD be in the derived model code
         expected_block = """
         class DerivedModelWithNewProperty(BaseModelWithoutProperty):
-            valueInteger: Integer = Field(
+            valueInteger: fhir.integer = Field(
                 description="Another value.",
             )
 
@@ -907,7 +908,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         # Create a grandparent model with a property
         grandparent_model = _create_model(
             "GrandparentWithProperty",
-            value=(primitives.String, Field(description="A value.")),
+            value=(primitives.string, Field(description="A value.")),
             __base__=(BaseModel,),
         )
         setattr(
@@ -921,14 +922,14 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         # Create a parent model that inherits from grandparent
         parent_model = _create_model(
             "ParentModel",
-            parentField=(primitives.String, Field(description="Parent field.")),
+            parentField=(primitives.string, Field(description="Parent field.")),
             __base__=(grandparent_model,),
         )
 
         # Create a child model that inherits from parent but doesn't override the property
         child_model = _create_model(
             "ChildModel",
-            childField=(primitives.String, Field(description="Child field.")),
+            childField=(primitives.string, Field(description="Child field.")),
             __base__=(parent_model,),
         )
 
@@ -955,7 +956,7 @@ class TestJinjaTemplateRendering(unittest.TestCase):
         model = create_model(
             "ModelWithProhibitedField",
             active=(
-                primitives.Boolean,
+                primitives.boolean,
                 Field(default=None, description="Active flag."),
             ),
             prohibited=(


### PR DESCRIPTION
This PR changes the code generator's output to use lowercase type aliases prefixed with a `fhir` module alias (e.g. `fhir.string`, `fhir.integer`), aligned with FHIR nthe type alias design of the primitive module.

## Fixed

- Generated FHIR resource models now use lowercase primitive type aliases prefixed with a `fhir` module alias (e.g. `fhir.string`, `fhir.integer`) instead of importing and referencing the primitive classes directly (e.g. `String`, `Integer`). 