### PR TITLE
Improve StructureDefinition resolution for differential inheritance chains

### DIFF
--- a/fhircraft/fhir/resources/factory/resolver.py
+++ b/fhircraft/fhir/resources/factory/resolver.py
@@ -83,7 +83,7 @@ class SnapshotResolver:
                 "differential"
                 if sd.baseDefinition
                 and sd.differential
-                and len(sd.differential.element or []) > 1
+                and len(sd.differential.element or []) > 0
                 else "snapshot"
             )
         if mode == "snapshot":
@@ -117,22 +117,9 @@ class SnapshotResolver:
                 raise DefinitionResolutionError(
                     f"StructureDefinition '{getattr(sd, 'name', '?')}' has no baseDefinition, which is required for differential resolution."
                 )
-            # Obtain the base snapshot for differential resolution
+            # Build base index by recursively applying ancestor differentials.
             base_definition = self._registry.get(str(base_canonical))
-            partial_base_index = self.resolve(base_definition, mode="auto")
-            if base_definition.snapshot and base_definition.snapshot.element:
-                base_index = DefinitionIndex.from_elements(
-                    base_definition.snapshot.element
-                )
-                base_index.update(partial_base_index.nodes, replace=True)
-            else:
-
-                ancestor_base_index = self._build_full_ancestor_index(base_definition)
-                if ancestor_base_index.root().id == partial_base_index.root().id:
-                    ancestor_base_index.update(partial_base_index.nodes, replace=True)
-                    base_index = ancestor_base_index
-                else:
-                    base_index = partial_base_index
+            base_index = self._resolve_base_chain(base_definition)
             # Merge differential over base snapshot to produce a synthetic snapshot
             resolved_index = self._resolve_differential(
                 sd.differential.element, base_index
@@ -151,6 +138,59 @@ class SnapshotResolver:
     # ------------------------------------------------------------------
     # Differential resolution
     # ------------------------------------------------------------------
+
+    def _resolve_base_chain(
+        self,
+        sd: "R4_StructureDefinition | R4B_StructureDefinition | R5_StructureDefinition",
+    ) -> DefinitionIndex:
+        """
+        Resolve an ancestor StructureDefinition into a usable base index for
+        differential merging.
+
+        Resolution is differential-first: when a definition has a differential,
+        it is merged on top of its own resolved base chain. Snapshot is used when
+        a definition has no baseDefinition (chain anchor), or when a level has no
+        differential but provides a snapshot.
+        """
+        if sd.baseDefinition:
+            parent_sd = self._registry.get(str(sd.baseDefinition))
+            parent_index = self._resolve_base_chain(parent_sd)
+
+            if sd.differential and sd.differential.element:
+                assert all(
+                    [e is not None for e in sd.differential.element]
+                ), f"StructureDefinition {sd.name or sd.url} differential.element contains None"
+                resolved_diff = self._resolve_differential(
+                    sd.differential.element, parent_index
+                )
+                # Keep untouched inherited nodes by overlaying the resolved differential onto the fully resolved parent chain.
+                if resolved_diff.root().id == parent_index.root().id:
+                    merged_parent = DefinitionIndex.from_elements(
+                        [n.definition for n in parent_index.nodes]
+                    )
+                    merged_parent.update(resolved_diff.nodes, replace=True)
+                    return merged_parent
+
+                # Otherwise prefer the snapshot if available as a complete bridge.
+                if sd.snapshot and sd.snapshot.element:
+                    snapshot_index = DefinitionIndex.from_elements(sd.snapshot.element)
+                    snapshot_index.update(resolved_diff.nodes, replace=True)
+                    return snapshot_index
+
+                return resolved_diff
+
+            if sd.snapshot and sd.snapshot.element:
+                return DefinitionIndex.from_elements(sd.snapshot.element)
+
+            return parent_index
+
+        if sd.snapshot and sd.snapshot.element:
+            return DefinitionIndex.from_elements(sd.snapshot.element)
+
+        raise DefinitionResolutionError(
+            f"StructureDefinition '{getattr(sd, 'name', '?')}' has no baseDefinition and no snapshot; "
+            "cannot anchor differential resolution."
+        )
 
     def _build_full_ancestor_index(
         self,
@@ -182,7 +222,7 @@ class SnapshotResolver:
                     f"StructureDefinition '{getattr(current, 'name', '?')}' has neither a "
                     "snapshot nor a baseDefinition — cannot reconstruct full ancestor index."
                 )
-            ancestor = self._registry.get(current.baseDefinition)
+            ancestor = self._registry.get(str(current.baseDefinition))
             if ancestor.snapshot and ancestor.snapshot.element:
                 return DefinitionIndex.from_elements(ancestor.snapshot.element)
             current = ancestor

--- a/test/test_fhir_resources_factory_resolver.py
+++ b/test/test_fhir_resources_factory_resolver.py
@@ -1650,3 +1650,143 @@ def test_build_full_ancestor_index__raises_when_chain_has_no_snapshot(resolver):
 
     with pytest.raises(DefinitionResolutionError):
         resolver._build_full_ancestor_index(sd_a)
+
+
+# ==================================================================
+# SnapshotResolver._resolve_base_chain
+# ==================================================================
+
+
+def test_resolve_base_chain__anchors_on_snapshot_when_no_base_definition(
+    resolver, base_index
+):
+    sd = make_structure_def(snapshot_elements=[n.definition for n in base_index.nodes])
+
+    result = resolver._resolve_base_chain(sd)
+
+    assert isinstance(result, DefinitionIndex)
+    assert result.root().id == "BaseResource"
+    assert result.get("BaseResource.status") is not None
+
+
+def test_resolve_base_chain__raises_when_no_base_definition_and_no_snapshot(resolver):
+    sd = make_structure_def(snapshot_elements=None, differential_elements=None)
+
+    with pytest.raises(DefinitionResolutionError):
+        resolver._resolve_base_chain(sd)
+
+
+def test_resolve_base_chain__applies_differential_on_parent_chain_and_keeps_untouched(
+    resolver,
+):
+    root_sd = make_structure_def(
+        snapshot_elements=[
+            make_element("BaseResource", "BaseResource"),
+            make_element(
+                "BaseResource.status",
+                "BaseResource.status",
+                min=0,
+                max="1",
+                type=[ElementDefinitionType(code="code")],
+            ),
+            make_element(
+                "BaseResource.category",
+                "BaseResource.category",
+                min=0,
+                max="*",
+                type=[ElementDefinitionType(code="CodeableConcept")],
+            ),
+        ]
+    )
+
+    # Differential only touches status; category must still be inherited.
+    mid_sd = make_structure_def(
+        differential_elements=[
+            make_element("BaseResource", "BaseResource"),
+            make_element("BaseResource.status", "BaseResource.status", min=1),
+        ],
+        base_definition="http://example.org/BaseResource",
+    )
+
+    resolver._registry.get = MagicMock(return_value=root_sd)
+
+    result = resolver._resolve_base_chain(mid_sd)
+
+    status_node = result.get("BaseResource.status")
+    category_node = result.get("BaseResource.category")
+    assert status_node is not None
+    assert status_node.min_cardinality == 1
+    assert category_node is not None
+    assert any(str(t.code) == "CodeableConcept" for t in category_node.types)
+
+
+def test_resolve_base_chain__uses_snapshot_bridge_when_root_changes(resolver):
+    # Parent root is DomainResource, child differential root is Patient.
+    parent_sd = make_structure_def(
+        snapshot_elements=[
+            make_element("DomainResource", "DomainResource"),
+            make_element(
+                "DomainResource.text",
+                "DomainResource.text",
+                min=0,
+                max="1",
+                type=[ElementDefinitionType(code="Narrative")],
+            ),
+        ]
+    )
+
+    child_sd = make_structure_def(
+        snapshot_elements=[
+            make_element("Patient", "Patient"),
+            make_element(
+                "Patient.id",
+                "Patient.id",
+                min=0,
+                max="1",
+                type=[ElementDefinitionType(code="id")],
+            ),
+            make_element(
+                "Patient.active",
+                "Patient.active",
+                min=0,
+                max="1",
+                type=[ElementDefinitionType(code="boolean")],
+            ),
+        ],
+        differential_elements=[
+            make_element("Patient", "Patient"),
+            make_element("Patient.id", "Patient.id", min=1, max="1"),
+        ],
+        base_definition="http://example.org/DomainResource",
+    )
+
+    resolver._registry.get = MagicMock(return_value=parent_sd)
+
+    result = resolver._resolve_base_chain(child_sd)
+
+    assert result.root().id == "Patient"
+    assert result.get("Patient.active") is not None
+    id_node = result.get("Patient.id")
+    assert id_node is not None
+    assert id_node.min_cardinality == 1
+    assert id_node.max_cardinality == 1
+
+
+def test_resolve_base_chain__returns_parent_index_when_no_snapshot_or_differential(
+    resolver, base_index
+):
+    root_sd = make_structure_def(
+        snapshot_elements=[n.definition for n in base_index.nodes]
+    )
+    child_sd = make_structure_def(
+        snapshot_elements=None,
+        differential_elements=None,
+        base_definition="http://example.org/BaseResource",
+    )
+
+    resolver._registry.get = MagicMock(return_value=root_sd)
+
+    result = resolver._resolve_base_chain(child_sd)
+
+    assert result.root().id == "BaseResource"
+    assert result.get("BaseResource.status") is not None


### PR DESCRIPTION
This PR improves how inherited FHIR profiles are resolved so generated models more faithfully reflect layered differential constraints and inherited metadata.

### Changed
- Improved StructureDefinition resolution to follow differential inheritance chains instead of stopping at the first available snapshot

### Fixed
- Fixed construction of resources where resolution could miss inherited type information or slicing metadata when an intermediate definition had no complete snapshot
