### PR TITLE
Fix type-choice constrained children so extension slices are generated on typed values

### DIFF
--- a/fhircraft/fhir/resources/factory/builders/type_choice.py
+++ b/fhircraft/fhir/resources/factory/builders/type_choice.py
@@ -17,6 +17,7 @@ from fhircraft.fhir.resources.validators import (
     validate_type_choice_element,
     get_type_choice_value_by_base,
 )
+from fhircraft.utils import capitalize
 
 
 class TypeChoiceFieldBuilder(Builder):
@@ -25,6 +26,7 @@ class TypeChoiceFieldBuilder(Builder):
         return node.is_polymorphic_type
 
     def build(self, node: ElementNode, index: DefinitionIndex) -> Build:
+        from fhircraft.fhir.resources.factory.assembler import ModelAssembler
 
         build = Build()
         base_name = node.name
@@ -35,10 +37,42 @@ class TypeChoiceFieldBuilder(Builder):
                 f"Element '{node.path}' is a type choice but has none of its types could be resolved"
             )
 
-        for field_type_info in field_type_infos:
-            field_type = field_type_info.type
+        sub_models: dict[str, type] = {}
+        children = index.get_children(node.id)
+        if isinstance(children, list) and children:
+            subtree = index.get_subtree(node.id)
+            for field_type_info in field_type_infos:
+                original_type = field_type_info.type
+                type_name = (
+                    original_type
+                    if isinstance(original_type, str)
+                    else original_type.__name__
+                )
+                sub_model_name = (
+                    f"{self.context.resource_name}{capitalize(base_name)}{type_name}"
+                )
+                assembler = ModelAssembler(
+                    index=subtree,
+                    ctx=self.context,
+                    resource_name=sub_model_name,
+                )
+                sub_models[type_name] = assembler.assemble(
+                    sub_model_name, base=(original_type,)
+                )
 
-            typed_name = f"{base_name}{field_type if isinstance(field_type, str) else field_type.__name__}"
+        for field_type_info in field_type_infos:
+            original_type = field_type_info.type
+            type_name = (
+                original_type
+                if isinstance(original_type, str)
+                else original_type.__name__
+            )
+            # Use the sub-model as the actual field type when children are present;
+            # the field name always uses the original (base) type name so that the
+            # type-choice validator keeps working.
+            field_type = sub_models.get(type_name, original_type)
+
+            typed_name = f"{base_name}{type_name}"
             safe_name, validation_alias = self.handle_python_keyword(typed_name)
 
             build.fields.append(

--- a/fhircraft/fhir/resources/factory/resolver.py
+++ b/fhircraft/fhir/resources/factory/resolver.py
@@ -174,6 +174,28 @@ class SnapshotResolver:
                 # Otherwise prefer the snapshot if available as a complete bridge.
                 if sd.snapshot and sd.snapshot.element:
                     snapshot_index = DefinitionIndex.from_elements(sd.snapshot.element)
+                    parent_root = parent_index.root().id
+                    snap_root = snapshot_index.root().id
+                    for node in snapshot_index.nodes:
+                        if node.is_slice_entry or not node.id.startswith(
+                            snap_root + "."
+                        ):
+                            continue
+                        parent_id = parent_root + node.id[len(snap_root) :]
+                        if parent_id not in parent_index:
+                            continue
+                        parent_node = parent_index.get(parent_id)
+                        if parent_node.is_slice_entry:
+                            snapshot_index.add(
+                                ElementNode(
+                                    definition=node.definition.model_copy(
+                                        update={
+                                            "slicing": parent_node.definition.slicing
+                                        }
+                                    )
+                                ),
+                                replace=True,
+                            )
                     snapshot_index.update(resolved_diff.nodes, replace=True)
                     return snapshot_index
 
@@ -423,11 +445,17 @@ class SnapshotResolver:
             snapshot = type_structure_definition.snapshot
             if not snapshot or not snapshot.element:
                 continue
+            expected_local_id = local_id
+            if (
+                type_structure_definition.kind == "primitive-type"
+                and local_id.lower() == str(datatype).lower()
+            ):
+                expected_local_id = "value"
             matching_node = next(
                 (
                     n
                     for e in snapshot.element
-                    if (n := ElementNode(e)).local_id == local_id
+                    if (n := ElementNode(e)).local_id == expected_local_id
                 ),
                 None,
             )

--- a/fhircraft/fhir/resources/validators.py
+++ b/fhircraft/fhir/resources/validators.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Any, List, TypeVar, Union, Sequence
 from pydantic import BaseModel
 
 from fhircraft.config import get_config
-from fhircraft.utils import ensure_list, get_all_models_from_field, is_dict_subset
+from fhircraft.utils import (
+    capitalize,
+    ensure_list,
+    get_all_models_from_field,
+    is_dict_subset,
+)
 
 if TYPE_CHECKING:
     from fhircraft.fhir.resources.base import FHIRBaseModel, FHIRSliceModel
@@ -390,7 +395,11 @@ def validate_type_choice_element(
         return instance
 
     _field_types: List[str] = [
-        field_type if isinstance(field_type, str) else str(field_type.__name__)
+        (
+            capitalize(field_type)
+            if isinstance(field_type, str)
+            else capitalize(str(field_type.__name__))
+        )
         for field_type in field_types
     ]
     types_set_count = sum(
@@ -427,9 +436,7 @@ def validate_type_choice_element(
     ]
     # Check that non-allowed types are not set
     non_allowed_types = non_allowed_types or [
-        field_type
-        for field_type in all_types
-        if field_type.replace("_ext", "") not in _field_types
+        field_type for field_type in all_types if field_type not in _field_types
     ]
     if non_allowed_types:
         for non_allowed_type in non_allowed_types:
@@ -441,7 +448,7 @@ def validate_type_choice_element(
             value = getattr(instance, field_name, None)
             _assert(
                 value is None,
-                f"Type choice element {field_name_base}[x] cannot use non-allowed type '{non_allowed_type}'. ",
+                f"Type choice element {field_name_base}[x] cannot use non-allowed type '{non_allowed_type}'. Only the following types are allowed: {', '.join(_field_types)}. Got non-allowed type '{non_allowed_type}' with value '{value}'.",
             )
 
     return instance

--- a/test/test_doctest.py
+++ b/test/test_doctest.py
@@ -55,6 +55,7 @@ def mock_factory_build(
     **kwargs,
 ):
     """Mock construct_resource_model"""
+    print(f"Mock build called with canonical_url={canonical_url}, mode={mode}")
     if canonical_url:
         if canonical_url == "http://example.org/StructureDefinition/MyPatient":
             return Patient
@@ -73,8 +74,9 @@ def mock_factory_build(
             == "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient"
         ):
             return Patient
-        elif canonical_url.startswith(
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        elif (
+            canonical_url
+            == "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
         ):
             return Patient
         elif canonical_url.startswith(
@@ -184,6 +186,10 @@ def test_documentation_examples(mock_file, fpath):
     mock_load_package,
 )
 @patch("fhircraft.utils.load_file", mock_load_file)
+@patch(
+    "fhircraft.fhir.resources.factory.FHIRModelFactory.build",
+    mock_factory_build,
+)
 @patch("builtins.open", side_effect=mock_open_func)
 @pytest.mark.filterwarnings("ignore:.*dom-6.*")
 @pytest.mark.integration

--- a/test/test_fhir_resources_factory_builders_type_choice.py
+++ b/test/test_fhir_resources_factory_builders_type_choice.py
@@ -353,3 +353,58 @@ def test_build__no_extra_validators_when_nothing_set(builder, index):
     # Only the type-choice validator should be present
     assert len(result.validators) == 1
     assert result.validators[0].name == "value_type_choice_validator"
+
+
+# ===========================================================================
+# TypeChoiceFieldBuilder.build — constrained children sub-model assembly
+# ===========================================================================
+
+
+def test_build__with_constrained_children_builds_per_type_submodels(builder, index):
+    node = make_node("value", type_codes=["string", "Quantity"])
+    ti_string = make_type_info(primitives.String, "primitive")
+    ti_quantity = make_type_info(r4_complex.Quantity, "complex-type")
+
+    index.get_children.return_value = [MagicMock(name="child")]
+    subtree = MagicMock(name="subtree")
+    index.get_subtree.return_value = subtree
+
+    SubValueString = type("SubValueString", (), {})
+    SubValueQuantity = type("SubValueQuantity", (), {})
+
+    with patch.object(builder, "resolve_type", side_effect=[ti_string, ti_quantity]):
+        with patch(
+            "fhircraft.fhir.resources.factory.assembler.ModelAssembler"
+        ) as mock_assembler_cls:
+            assembler_instance = mock_assembler_cls.return_value
+            assembler_instance.assemble.side_effect = [
+                SubValueString,
+                SubValueQuantity,
+            ]
+
+            result = builder.build(node, index)
+
+    # A sub-model is assembled once per resolved type.
+    assert mock_assembler_cls.call_count == 2
+    assert assembler_instance.assemble.call_count == 2
+
+    field_by_name = {f.name: f for f in result.fields}
+    assert field_by_name["valueString"].annotation == Optional[SubValueString]
+    assert field_by_name["valueQuantity"].annotation == Optional[SubValueQuantity]
+
+
+def test_build__without_children_does_not_assemble_submodels(builder, index):
+    node = make_node("value", type_codes=["Quantity"])
+    ti_quantity = make_type_info(r4_complex.Quantity, "complex-type")
+
+    index.get_children.return_value = []
+
+    with patch.object(builder, "resolve_type", return_value=ti_quantity):
+        with patch(
+            "fhircraft.fhir.resources.factory.assembler.ModelAssembler"
+        ) as mock_assembler_cls:
+            result = builder.build(node, index)
+
+    mock_assembler_cls.assert_not_called()
+    assert result.fields[0].name == "valueQuantity"
+    assert result.fields[0].annotation == Optional[r4_complex.Quantity]

--- a/test/test_fhir_resources_factory_resolver.py
+++ b/test/test_fhir_resources_factory_resolver.py
@@ -177,12 +177,10 @@ def test_build_type_node__returns_correct_node(base_index, resolver, id):
 def test_build_type_node__resolves_sub_elements_on_primitive_types(
     base_index, resolver, primitive_type
 ):
-    node = resolver._build_type_node(
-        [primitive_type], "Observation.extension", base_index
-    )
+    node = resolver._build_type_node([primitive_type], "value[x].extension", base_index)
     assert isinstance(node, ElementNode)
-    assert node.id == "Observation.extension"
-    assert node.path == "Observation.extension"
+    assert node.id == "value[x].extension"
+    assert node.path == "value[x].extension"
 
 
 @pytest.mark.parametrize(
@@ -287,6 +285,28 @@ def test_build_type_node__resolves_extension_element_on_primitive_type(
     assert isinstance(node, ElementNode)
     assert node.id == "BaseResource.status.extension"
     assert node.path == "BaseResource.status.extension"
+
+
+@pytest.mark.parametrize(
+    "expanded_id, expected_path",
+    [
+        ("Patient.deceased[x].extension", "Patient.deceased[x].extension"),
+        (
+            "Patient.deceased[x]:deceasedBoolean.extension",
+            "Patient.deceased[x].extension",
+        ),
+    ],
+)
+def test_build_type_node__resolves_primitive_extension_on_type_choice_element(
+    resolver, expanded_id, expected_path
+):
+    base_index = make_base_index(make_element("Patient", "Patient"))
+
+    node = resolver._build_type_node(["boolean"], expanded_id, base_index)
+
+    assert isinstance(node, ElementNode)
+    assert node.id == expanded_id
+    assert node.path == expected_path
 
 
 def test_build_intermediate_node__resolves_extension_on_primitive_element(resolver):


### PR DESCRIPTION
This PR fixes an edge case where constraints defined under a type-choice element (for example, extensions under `deceased[x]`) were not fully represented in generated models.

### Changed
- Updated type-choice field building so typed fields can use assembled submodels (when child constraints exist), while preserving existing type-choice field names and validators.

### Fixed
- Fixed missing propagation of constrained children (including extension slicing use cases) for type-choice values in generated models.
- Fixed model assembly path for profiles that constrain children on typed type-choice branches.
