### PR TITLE
Ensure that FHIRPath `getValue()` returns the root value of primitives

### DIFF
--- a/fhircraft/fhir/path/engine/additional.py
+++ b/fhircraft/fhir/path/engine/additional.py
@@ -184,7 +184,11 @@ class GetValue(FHIRPathFunction):
                 value = value.to_datetime()
 
             has_primitive_value = value is not None and is_fhir_primitive(value)
-            return [FHIRPathCollectionItem.wrap(value)] if has_primitive_value else []
+            return (
+                [FHIRPathCollectionItem.wrap(getattr(value, "value", value))]
+                if has_primitive_value
+                else []
+            )
 
 
 class Resolve(FHIRPathFunction):

--- a/test/test_fhir_path_engine_additional.py
+++ b/test/test_fhir_path_engine_additional.py
@@ -7,20 +7,24 @@ from fhircraft.fhir.path.engine.additional import *
 from fhircraft.fhir.path.engine.core import *
 from fhircraft.fhir.path.engine.environment import EnvironmentVariable
 from fhircraft.fhir.path.engine.literals import Date, DateTime
+from fhircraft.fhir.resources.base import FHIRPrimitiveModel
 from fhircraft.fhir.resources.datatypes import get_fhir_type
 from fhircraft.fhir.resources.datatypes.R4.complex import (
     Quantity as R4_Quantity,
     Age as R4_Age,
     Extension as R4_Extension,
 )
+from fhircraft.fhir.resources.datatypes.R4.primitive.boolean import Boolean
 from fhircraft.fhir.resources.datatypes.R4B.complex import (
     Quantity as R4B_Quantity,
     Reference as R4B_Reference,
 )
+from fhircraft.fhir.resources.datatypes.R4B.primitive.string import String
 from fhircraft.fhir.resources.datatypes.R5.complex import (
     Quantity as R5_Quantity,
     Reference as R5_Reference,
 )
+from fhircraft.fhir.resources.datatypes.R5.primitive.integer import Integer
 
 env = dict()
 
@@ -107,10 +111,14 @@ def test_hasvalue_returns_false_for_collection_with_multiple_items():
 
 get_value_cases = (
     "ABC",
+    String(value="ABC"),
     123,
+    Integer(value=123),
     1.23,
     True,
+    Boolean(value=True),
     False,
+    Boolean(value=False),
     Date("@2012"),
     Date("@2012-01"),
     DateTime("@2012-01-01T10:30"),
@@ -129,6 +137,8 @@ def test_getvalue_returns_empty_for_empty_collection():
 def test_getvalue_returns_value_for_singleton_collection_with_primitive_value(value):
     collection = [FHIRPathCollectionItem(value=value)]
     result = GetValue().evaluate(collection, env)
+    if isinstance(value, FHIRPrimitiveModel):
+        value = value.value
     assert result[0].value == value
 
 


### PR DESCRIPTION
This PRpdates the handling of FHIR primitive values in the FHIRPath `getValue` function and expands test coverage to include additional FHIR primitive types. The main change ensures that when extracting values from FHIR primitive objects, the underlying primitive value is properly unwrapped. The tests are updated to verify correct behavior for both raw values and FHIR primitive model instances.


### Fixed

* Fixed the FHIRPath `getValue()` fucntion to correctly unwrap the `value` attribute from FHIR primitive objects before returning, ensuring the function returns the actual primitive value rather than the wrapper object.