### PR TITLE
Add unit conversion support to FHIRPath `toQuantity()` and `convertsToQuantity()`

### DIFF
--- a/fhircraft/fhir/path/engine/conversion.py
+++ b/fhircraft/fhir/path/engine/conversion.py
@@ -20,6 +20,7 @@ from fhircraft.fhir.path.engine.core import (
     FHIRPathCollection,
     FHIRPathCollectionItem,
     FHIRPathFunction,
+    Literal,
 )
 from fhircraft.fhir.path.exceptions import FHIRPathRuntimeError
 from fhircraft.fhir.path.utils import get_expression_context
@@ -588,6 +589,12 @@ class ToQuantity(FHIRTypeConversionFunction):
     A representation of the FHIRPath [`toQuantity()`](http://hl7.org/fhirpath/N1/#toquantity-string) function.
     """
 
+    def __init__(self, unit: str | Literal | None = None):
+        if unit is not None:
+            self.unit = unit if isinstance(unit, str) else unit.value
+        else:
+            self.unit = None
+
     def evaluate(
         self, collection: FHIRPathCollection, environment: dict, create: bool = False
     ) -> FHIRPathCollection:
@@ -620,32 +627,40 @@ class ToQuantity(FHIRTypeConversionFunction):
         if isinstance(value, FHIRPrimitiveModel):
             value = value.value
         if isinstance(value, (bool, int, float)):
-            return [FHIRPathCollectionItem.wrap(Quantity(value=float(value), unit=""))]
+            qty = Quantity(value=float(value), unit="")
         elif isinstance(value, str):
             quantity_match = re.match(
                 r"((\+|-)?\d+(\.\d+)?)\s*(('([^']+)'|([a-zA-Z\[\]]+))?)", value
             )
             if quantity_match:
-                return [
-                    FHIRPathCollectionItem.wrap(
-                        Quantity(
-                            value=float(quantity_match.group(1)),
-                            unit=quantity_match.group(4),
-                        )
-                    )
-                ]
+                qty = Quantity(
+                    value=float(quantity_match.group(1)),
+                    unit=quantity_match.group(4),
+                )
             else:
                 return []
         elif Quantity.is_quantity(value) and value is not None:
-            return [FHIRPathCollectionItem.wrap(Quantity.parse_quantity(value))]
+            qty = Quantity.parse_quantity(value)
         else:
             return []
+        if self.unit is not None:
+            if qty.unit == "":
+                qty.unit = self.unit
+            else:
+                qty = qty.convert_to(self.unit)
+        return [FHIRPathCollectionItem.wrap(qty)]
 
 
 class ConvertsToQuantity(FHIRTypeConversionFunction):
     """
     A representation of the FHIRPath [`convertsToQuantity()`](http://hl7.org/fhirpath/N1/#convertstoquantity-boolean) function.
     """
+
+    def __init__(self, unit: str | Literal | None = None):
+        if unit is not None:
+            self.unit = unit if isinstance(unit, str) else unit.value
+        else:
+            self.unit = None
 
     def evaluate(
         self, collection: FHIRPathCollection, environment: dict, create: bool = False
@@ -673,11 +688,15 @@ class ConvertsToQuantity(FHIRTypeConversionFunction):
         self.validate_collection(collection)
         if not collection:
             return []
-        return [
-            FHIRPathCollectionItem.wrap(
-                ToQuantity().evaluate(collection, environment, create) != []
-            )
-        ]
+        try:
+            return [
+                FHIRPathCollectionItem.wrap(
+                    ToQuantity(self.unit).evaluate(collection, environment, create)
+                    != []
+                )
+            ]
+        except ValueError:
+            return [FHIRPathCollectionItem.wrap(False)]
 
 
 class ToString(FHIRTypeConversionFunction):

--- a/fhircraft/fhir/path/engine/literals.py
+++ b/fhircraft/fhir/path/engine/literals.py
@@ -88,16 +88,31 @@ class Quantity(FHIRPathLiteralType):
         else:
             raise TypeError("Input must be a FHIRPath Quantity or FHIR Quantity type.")
 
+    @staticmethod
+    def clean_unit_string(unit_str: str) -> str:
+        # UCUM square brackets not supported by Pint; replace with nothing
+        unit_str = unit_str.replace("[", "").replace("]", "")
+        # UCUM single-quotes not supported by Pint; replace with underscores
+        unit_str = unit_str.replace("'", "_")
+        # UCUM curly braces not supported by Pint; replace with nothing
+        unit_str = re.sub(r"\{.*?\}", "_1", unit_str)
+        return unit_str
+
     @property
     def registry_unit(self) -> PintQuantity:
         _unit = self.unit or ""
-        # UCUM square brackets not supported by Pint; replace with nothing
-        _unit = _unit.replace("[", "").replace("]", "")
-        # UCUM single-quotes not supported by Pint; replace with underscores
-        _unit = _unit.replace("'", "_")
-        # UCUM curly braces not supported by Pint; replace with nothing
-        _unit = re.sub(r"\{.*?\}", "_1", _unit)
+        _unit = self.clean_unit_string(_unit)
         return ureg(_unit)
+
+    def convert_to(self, target_unit: str) -> "Quantity":
+        target_unit_clean = self.clean_unit_string(target_unit)
+        try:
+            converted = (self.value * self.registry_unit).to(target_unit_clean)
+            return Quantity(value=converted.magnitude, unit=target_unit)
+        except Exception as e:
+            raise ValueError(
+                f"Cannot convert from {self.unit} to {target_unit}: {str(e)}"
+            ) from e
 
     def is_compatible_with(self, unit: "Quantity") -> bool:
         return self.registry_unit.is_compatible_with(unit.registry_unit)
@@ -138,14 +153,37 @@ class Quantity(FHIRPathLiteralType):
     def __lt__(self, other):
         return self.__comparison__(other, operator.lt)
 
+    def __rlt__(self, other):
+        return self.__comparison__(other, operator.lt)
+
     def __le__(self, other):
+        return self.__comparison__(other, operator.le)
+
+    def __rle__(self, other):
         return self.__comparison__(other, operator.le)
 
     def __gt__(self, other):
         return self.__comparison__(other, operator.gt)
 
+    def __rgt__(self, other):
+        return self.__comparison__(other, operator.gt)
+
     def __ge__(self, other):
         return self.__comparison__(other, operator.ge)
+
+    def __rge__(self, other):
+        return self.__comparison__(other, operator.ge)
+
+    def __radd__(self, other):
+        result = self.__math__(other, operator.add)
+        if not self.is_compatible_with(other):
+            raise ValueError(
+                f"Cannot perform additions between incompatible units: {self.unit} and {other.unit}"
+            )
+        return Quantity(
+            value=result.to(self.registry_unit).magnitude,
+            unit=self.unit,
+        )
 
     def __add__(self, other):
         result = self.__math__(other, operator.add)
@@ -169,11 +207,36 @@ class Quantity(FHIRPathLiteralType):
             unit=self.unit,
         )
 
+    def __rsub__(self, other):
+        result = self.__math__(other, operator.sub)
+        if not self.is_compatible_with(other):
+            raise ValueError(
+                f"Cannot perform subtractions between incompatible units: {self.unit} and {other.unit}"
+            )
+        return Quantity(
+            value=result.to(self.registry_unit).magnitude,
+            unit=self.unit,
+        )
+
     def __mul__(self, other):
         result = self.__math__(other, operator.mul)
         return Quantity(
             value=result.magnitude,
             unit=f"{self.unit}*{other.unit}",
+        )
+
+    def __rmul__(self, other):
+        result = self.__math__(other, operator.mul)
+        return Quantity(
+            value=result.magnitude,
+            unit=f"{self.unit}*{other.unit}",
+        )
+
+    def __rfloordiv__(self, other):
+        result = self.__math__(other, operator.floordiv)
+        return Quantity(
+            value=result.magnitude,
+            unit=f"{self.unit}/{other.unit}" if self.unit != other.unit else "",
         )
 
     def __floordiv__(self, other):
@@ -184,6 +247,13 @@ class Quantity(FHIRPathLiteralType):
         )
 
     def __truediv__(self, other):
+        result = self.__math__(other, operator.truediv)
+        return Quantity(
+            value=result.magnitude,
+            unit=f"{self.unit}/{other.unit}" if self.unit != other.unit else "",
+        )
+
+    def __rtruediv__(self, other):
         result = self.__math__(other, operator.truediv)
         return Quantity(
             value=result.magnitude,

--- a/test/test_fhir_path_engine_conversion.py
+++ b/test/test_fhir_path_engine_conversion.py
@@ -712,6 +712,19 @@ def test_toquantity_converts_correctly_for_valid_type(value, expected):
     assert result[0].value == expected
 
 
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        ("120.5 g", Quantity(value=0.1205, unit="kg")),
+        ("12.5", Quantity(value=12.5, unit="kg")),
+    ),
+)
+def test_toquantity_converts_to_input_unit(value, expected):
+    collection = [FHIRPathCollectionItem(value=value)]
+    result = ToQuantity("kg").evaluate(collection, env)
+    assert result[0].value == expected
+
+
 def test_toQuantity_raises_error_for_multiple_items():
     collection = [FHIRPathCollectionItem(value=1), FHIRPathCollectionItem(value=2)]
     with pytest.raises(FHIRPathRuntimeError):
@@ -764,6 +777,21 @@ def test_convertstoquantity_returns_true_for_valid_type(value):
     collection = [FHIRPathCollectionItem(value=value)]
     result = ConvertsToQuantity().evaluate(collection, env)
     assert result == [FHIRPathCollectionItem.wrap(True)]
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        ("120.5 g", True),
+        ("12.5", True),
+        ("12.5 mL", False),
+        ("12.5 mm[Hg]", False),
+    ),
+)
+def test_convertstoquantity_returns_correct_conversion(value, expected):
+    collection = [FHIRPathCollectionItem(value=value)]
+    result = ConvertsToQuantity("kg").evaluate(collection, env)
+    assert result[0].value == expected
 
 
 def test_convertsToQuantity_raises_error_for_multiple_items():


### PR DESCRIPTION
This pull request enhances the handling of FHIRPath quantity conversions in the `fhircraft` library. The main improvements include supporting unit conversion in `toQuantity()` and `convertsToQuantity()`, robust unit string normalization, and expanded arithmetic capabilities for the `Quantity` type. The test suite is also updated to cover these new features.

### Fixed 

* Updated `ToQuantity` and `ConvertsToQuantity` to now accept an optional unit parameter, allowing conversion to a specified unit and handling unit compatibility.  Fixes #310
* Added `clean_unit_string` and `convert_to` methods to the `Quantity` class to standardize and convert units, improving compatibility with the Pint library and UCUM unit conventions.
