### PR TITLE
Update release workflow for tokenless PyPI publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,11 @@ jobs:
 
   pypi-build-n-publish:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fhircraft
+    permissions:
+      id-token: write
     steps:
     - name: Checkout
       uses: actions/checkout@v1
@@ -21,8 +26,5 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: >-
         python -m build --sdist --wheel --outdir dist/
-    - name: Publish distribution to PyPI
+    - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}s

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,9 +15,9 @@ jobs:
       id-token: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v6
     - name: Set up Python 3.11
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
     - name: Install pypa/build


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing to PyPI by renaming the workflow file, improving environment configuration, and updating the publishing step for better security and clarity.

### Changed

* Renamed `.github/workflows/package.yaml` to `.github/workflows/release.yaml` for clearer workflow naming.
* Added an explicit `environment` block for the PyPI deployment, specifying both the environment name and URL.
* Granted `id-token: write` permission to enable trusted publishing to PyPI using GitHub OIDC.
* Updated the publish step to use the more secure `pypa/gh-action-pypi-publish@release/v1` action without explicit username and password, aligning with modern best practices for PyPI publishing.