### PR TITLE
Fix dependency constraints

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,10 +16,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
-    - name: Set up Python 3.11
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.11"
+        python-version: "3.x"
     - name: Install pypa/build
       run: >-
         python -m pip install build --user

--- a/fhircraft/fhir/mapper/engine/registry.py
+++ b/fhircraft/fhir/mapper/engine/registry.py
@@ -8,8 +8,7 @@ FHIR Mapping Language engine, with optional internet-fallback resolution.
 from typing import Any, Dict, Optional, Tuple, Union
 
 import requests
-from pydantic import BaseModel
-from pydantic_core import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from fhircraft.config import override_config
 from fhircraft.fhir.resources.datatypes.R4 import core as R4_models

--- a/fhircraft/fhir/resources/base/models.py
+++ b/fhircraft/fhir/resources/base/models.py
@@ -7,8 +7,7 @@ import warnings
 from abc import ABC
 from copy import copy
 from itertools import zip_longest
-from typing import Any, ClassVar, Iterable, Mapping, SupportsIndex, Union, Literal
-from typing_extensions import Self
+from typing import Any, ClassVar, Iterable, Mapping, SupportsIndex, Union, Literal, Self
 
 from pydantic.config import ExtraValues
 from pydantic import (

--- a/fhircraft/fhir/resources/factory/builders/base.py
+++ b/fhircraft/fhir/resources/factory/builders/base.py
@@ -18,7 +18,6 @@ from functools import partial
 import keyword
 
 from dataclasses import dataclass, field as dc_field
-from typing_extensions import Annotated
 
 from pydantic import Field, field_validator, model_validator
 from pydantic.aliases import AliasChoices

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     'Framework :: Pydantic',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
-requires-python = '>=3.10'
+requires-python = '>=3.11'
 readme = "README.md"
 dependencies = [
     'requests',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ readme = "README.md"
 dependencies = [
     'requests',
     'pydantic>=2.7',
+    'pydantic_core>=2.18',
     'ply>=3.11',
     'pyyaml>=6.0.1',
     'python-dotenv>=1.0',
@@ -44,7 +45,8 @@ dependencies = [
     'jsonpath-ng>1',
     'jinja2>=3.1',
     'Pint>=0.24',
-    'packaging>=25'
+    'packaging>=25',
+    'typing_extensions>=4.6.0',
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,14 +35,14 @@ classifiers = [
 requires-python = '>=3.11'
 readme = "README.md"
 dependencies = [
-    'requests',
+    'requests>=2.28',
     'pydantic>=2.7',
     'pydantic_core>=2.18',
     'ply>=3.11',
     'pyyaml>=6.0.1',
     'python-dotenv>=1.0',
-    'jsonschema>4',
-    'jsonpath-ng>1',
+    'jsonschema>=4',
+    'jsonpath-ng>=1',
     'jinja2>=3.1',
     'Pint>=0.24',
     'packaging>=25',
@@ -53,9 +53,9 @@ dependencies = [
 cli = ["typer==0.12.3"]
 dev = [
     "pytest>=8.2",
-    "pytest-mock==3.14.0",
-    "parameterized==0.9.0",
-    "coverage==7.5.1",
+    "pytest-mock>=3.14.0",
+    "parameterized>=0.9.0",
+    "coverage>=7.5.1",
 ]
 docs = [
     "mkdocs-material==9.5.27",

--- a/test/test_fhir_resources_factory_builders_base.py
+++ b/test/test_fhir_resources_factory_builders_base.py
@@ -1,8 +1,7 @@
 import keyword
-from typing_extensions import get_args, get_origin
 from unittest.mock import MagicMock
 import pytest
-from typing import Any, List, Optional
+from typing import Any, List, Optional, get_args, get_origin
 from pydantic.aliases import AliasChoices
 from fhircraft.fhir.resources.datatypes.R4 import core, complex, primitive
 from fhircraft.fhir.resources.datatypes.utils import get_fhir_type

--- a/test/test_fhir_resources_regression.py
+++ b/test/test_fhir_resources_regression.py
@@ -1,4 +1,4 @@
-from typing_extensions import get_args, get_origin
+from typing import get_args, get_origin
 
 import pytest
 from pydantic import ValidationError


### PR DESCRIPTION

### Added
- Added explicit dependency pins for `pydantic_core` `typing_extensions`. Fixes #362

### Changed
- Updated package Python requirement from `>=3.10` to `>=3.11`.
- Updated release workflow Python setup to use 3.x instead of a fixed 3.11 patch target.
- Tightened the  lower bounds for development dependencies and the `requests` dependency.  Closes #372 

### Fixes
- Replacing typing_extensions imports with standard typing equivalents where available.
- Fixed ValidationError import to use pydantic directly instead of pydantic_core in mapper registry logic.
