### PR TITLE
Fix FHIRPath `Resolve` function to ignore non-reference items and prevent incorrect exceptions

### DIFF
--- a/fhircraft/fhir/path/engine/additional.py
+++ b/fhircraft/fhir/path/engine/additional.py
@@ -230,9 +230,7 @@ class Resolve(FHIRPathFunction):
                 )
                 or ((resource_url := value))
             ) or not isinstance(resource_url, (str, StringBase)):
-                raise FhirPathException(
-                    "The resolve() function requires either a collection of URIs, Canonicals, URLs or References."
-                )
+                continue
             if resource_url.startswith("http://"):
                 # Resolving URLs is not supported
                 warnings.warn(

--- a/test/test_fhir_path_engine_additional.py
+++ b/test/test_fhir_path_engine_additional.py
@@ -561,3 +561,14 @@ def test_resolve_with_unresolvable_internal_reference():
     collection = [FHIRPathCollectionItem(value="#1234")]
     result = Resolve().evaluate(collection, {"%resource": resource})
     assert result == []
+
+
+def test_resolve_ignores_non_reference_items():
+    contained_resource = {"id": "123", "resourceType": "Patient"}
+    resource = {"contained": [contained_resource]}
+    collection = [
+        FHIRPathCollectionItem(value="#123"),
+        FHIRPathCollectionItem(value=123),
+    ]
+    result = Resolve().evaluate(collection, {"%resource": resource})
+    assert result[0].value == contained_resource


### PR DESCRIPTION
This pull request updates the `resolve()` function in the FHIRPath engine to improve how it handles collections with non-reference items. Instead of raising an exception when encountering a non-reference item, the function now skips over those items. Additionally, a new test has been added to verify this behavior.

### Fixed 

* Fixed the FHIRPath `resolve()` function so that non-reference items in the collection are ignored (skipped) instead of causing an exception to be raised. Fixes #307 
