### PR TITLE
Implement FHIRPath terminology service support & Implement FHIRPath terminology-based functions

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -272,9 +272,11 @@ Use `override_config` when you need a different terminology service for a specif
 ```python
 from fhircraft import override_config
 
-with override_config(terminology_service=StagingTerminologyService()):
+Observation = get_fhir_type("Observation", "R5")
+
+with override_config(terminology_service=MyTerminologyService()):
     # All FHIRPath evaluations in this block use the staging service
-    result = obs.fhirpath_values(
+    result = Observation(code={"coding":[{"code":"LP-12292"}]}).fhirpath_single(
         "Observation.code.memberOf('http://example.org/ValueSet/LabCodes')"
     )
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -205,6 +205,82 @@ reset_config()
 
 Resetting proves useful in test suites where each test should start with clean configuration, or in long-running applications that process different types of data requiring different validation approaches.
 
+## Configuring the Terminology Service
+
+Fhircraft's FHIRPath terminology functions — `memberOf()`, `subsumes()`, and `subsumedBy()` — require a terminology service to produce results. You provide one by registering an object that implements the `TerminologyService` protocol from `fhircraft.fhir.terminology`.
+
+### The `TerminologyService` Protocol
+
+The protocol uses Python structural subtyping, so your class does not need to inherit from anything. It just needs to implement the relevant methods:
+
+```python
+from fhircraft.fhir.terminology import TerminologyService
+
+class MyTerminologyService:
+    """Delegates terminology operations to a remote FHIR server."""
+
+    def validate_valueset_code(self, *, url=None, code=None, system=None,
+                               version=None, display=None) -> bool:
+        # ValueSet/$validate-code
+        ...
+
+    def validate_codesystem_code(self, *, url=None, code=None,
+                                 version=None, display=None) -> bool:
+        # CodeSystem/$validate-code
+        ...
+
+    def codesystem_lookup(self, *, code, system=None, version=None):
+        # CodeSystem/$lookup
+        ...
+
+    def codesystem_subsumes(self, codeA, codeB, system=None, version=None):
+        # CodeSystem/$subsumes
+        ...
+
+# Verify structural compatibility at runtime
+assert isinstance(MyTerminologyService(), TerminologyService)
+```
+
+You only need to implement the methods that your application actually calls. Unimplemented methods that raise `NotImplementedError` are handled gracefully by the FHIRPath engine — they cause the function to return an empty collection rather than crashing.
+
+### Registering Globally
+
+Use `configure()` to set a default terminology service for the entire application. The service is then used automatically by all `memberOf()`, `subsumes()`, and `subsumedBy()` FHIRPath evaluations:
+
+```python
+from fhircraft import configure
+
+configure(terminology_service=MyTerminologyService())
+```
+
+### Clearing the Service
+
+Pass `None` explicitly to remove a previously registered service:
+
+```python
+from fhircraft import configure
+
+configure(terminology_service=None)  # (1)!
+```
+
+1. Omitting the argument entirely leaves the existing service unchanged. Only `None` clears it.
+
+### Scoped Service with `override_config`
+
+Use `override_config` when you need a different terminology service for a specific block of code without affecting the global configuration:
+
+```python
+from fhircraft import override_config
+
+with override_config(terminology_service=StagingTerminologyService()):
+    # All FHIRPath evaluations in this block use the staging service
+    result = obs.fhirpath_values(
+        "Observation.code.memberOf('http://example.org/ValueSet/LabCodes')"
+    )
+
+# Global service (or no service) is automatically restored after the block
+```
+
 ## Common Problems and Solutions
 
 | Problem | Solution |

--- a/docs/user-guide/fhirpath.md
+++ b/docs/user-guide/fhirpath.md
@@ -241,6 +241,7 @@ Fhircraft automatically provides these environment variables in all FHIRPath eva
 | `%rootResource` | The root resource in the evaluation hierarchy (typically same as `%resource` for simple queries) | `Bundle` |
 | `%ucum` | The URL for the Unified Code for Units of Measure system | `http://unitsofmeasure.org` |
 | `%fhirRelease` | The FHIR release version of the node being evaluated in the expression | `R4B` |
+| `%terminologyService` | An optional terminology service instance used by `memberOf()`, `subsumes()`, and `subsumedBy()` | _(implementation object)_ |
 
 ```python
 from fhircraft.fhir.resources import get_fhir_type
@@ -482,4 +483,92 @@ print(patient.fhirpath_single("Patient.id is FHIR.id"))
 print(patient.fhirpath_single("Patient.id is FHIR.integer"))
 #> False
 ```
+
+## Terminology Functions
+
+Fhircraft implements the [:material-fire: FHIR-specific FHIRPath terminology functions](https://www.hl7.org/fhir/fhirpath.html#functions) — `memberOf()`, `subsumes()`, and `subsumedBy()`. These functions perform code-system lookups and value-set validation at query time, and they require a terminology service to be configured before they produce results.
+
+When no terminology service is present, all three functions return an empty collection rather than raising an error, so existing expressions remain safe in environments where terminology validation is not needed.
+
+### Providing a Terminology Service
+
+You can supply a terminology service in two ways:
+
+**Global configuration** — registers a default service used for all FHIRPath evaluations:
+
+```python
+from fhircraft import configure
+from fhircraft.fhir.terminology import TerminologyService
+
+class MyTerminologyService:
+    def validate_valueset_code(self, *, url, code, system=None, version=None, display=None):
+        # Delegate to a real terminology server, e.g. HAPI FHIR
+        ...
+
+    def codesystem_subsumes(self, codeA, codeB, system=None, version=None):
+        ...
+
+    def codesystem_lookup(self, *, code, system=None, version=None):
+        ...
+
+    def validate_codesystem_code(self, *, url=None, code=None, version=None, display=None):
+        ...
+
+configure(terminology_service=MyTerminologyService())
+```
+
+**Per-evaluation via environment variable** — passes a service only for a specific expression, overriding the global one:
+
+```python
+result = patient.fhirpath_values(
+    "Observation.code.memberOf('http://example.org/ValueSet/LabCodes')",
+    environment={"%terminologyService": MyTerminologyService()}
+)
+```
+
+### `memberOf(valueset)`
+
+Returns `true` if the source value (a `string`, `Coding`, or `CodeableConcept`) is a member of the given value set URL. Returns `false` if it is not a member, and returns an empty collection if the value set cannot be resolved or the service raises an error.
+
+```python
+from fhircraft.fhir.resources import get_fhir_type
+
+Observation = get_fhir_type("Observation", "R4")
+
+obs = Observation(
+    status="final",
+    code={"coding": [{"system": "http://loinc.org", "code": "55284-4"}]}
+)
+
+is_member = obs.fhirpath_single(
+    "Observation.code.memberOf('http://example.org/ValueSet/LabCodes')",
+    environment={"%terminologyService": my_service}
+)
+# True if the code is in the value set, False if not
+```
+
+### `subsumes(code)` and `subsumedBy(code)`
+
+`subsumes(code)` returns `true` if the source `Coding` is an ancestor of (or equivalent to) the given code in a subsumption hierarchy. `subsumedBy(code)` is the inverse — it returns `true` if the source code is a descendant of the given code.
+
+Both functions require that the source and argument `Coding` values belong to the **same code system**. Passing codings from different systems raises a `FhirPathException`. Both also accept `CodeableConcept` values, in which case the first coding in the concept is used.
+
+```python
+from fhircraft.fhir.resources.datatypes.R4.complex import Coding
+
+disease = Coding(system="http://snomed.info/sct", code="73211009")  # Diabetes mellitus
+parent  = Coding(system="http://snomed.info/sct", code="362969004") # Disorder of endocrine system
+
+result = patient.fhirpath_single(
+    "Observation.code.subsumes(%parent)",
+    environment={
+        "%terminologyService": my_service,
+        "%parent": parent,
+    }
+)
+```
+
+!!! info "Fallback behaviour"
+
+    If the terminology service returns `None` for a subsumption query (e.g. the relationship is unknown), both `subsumes()` and `subsumedBy()` return an empty collection rather than `false`.
 

--- a/docs/user-guide/fhirpath.md
+++ b/docs/user-guide/fhirpath.md
@@ -521,54 +521,7 @@ configure(terminology_service=MyTerminologyService())
 
 ```python
 result = patient.fhirpath_values(
-    "Observation.code.memberOf('http://example.org/ValueSet/LabCodes')",
+    "Patient.gender.memberOf('http://hl7.org/fhir/ValueSet/administrative-gender')",
     environment={"%terminologyService": MyTerminologyService()}
 )
 ```
-
-### `memberOf(valueset)`
-
-Returns `true` if the source value (a `string`, `Coding`, or `CodeableConcept`) is a member of the given value set URL. Returns `false` if it is not a member, and returns an empty collection if the value set cannot be resolved or the service raises an error.
-
-```python
-from fhircraft.fhir.resources import get_fhir_type
-
-Observation = get_fhir_type("Observation", "R4")
-
-obs = Observation(
-    status="final",
-    code={"coding": [{"system": "http://loinc.org", "code": "55284-4"}]}
-)
-
-is_member = obs.fhirpath_single(
-    "Observation.code.memberOf('http://example.org/ValueSet/LabCodes')",
-    environment={"%terminologyService": my_service}
-)
-# True if the code is in the value set, False if not
-```
-
-### `subsumes(code)` and `subsumedBy(code)`
-
-`subsumes(code)` returns `true` if the source `Coding` is an ancestor of (or equivalent to) the given code in a subsumption hierarchy. `subsumedBy(code)` is the inverse — it returns `true` if the source code is a descendant of the given code.
-
-Both functions require that the source and argument `Coding` values belong to the **same code system**. Passing codings from different systems raises a `FhirPathException`. Both also accept `CodeableConcept` values, in which case the first coding in the concept is used.
-
-```python
-from fhircraft.fhir.resources.datatypes.R4.complex import Coding
-
-disease = Coding(system="http://snomed.info/sct", code="73211009")  # Diabetes mellitus
-parent  = Coding(system="http://snomed.info/sct", code="362969004") # Disorder of endocrine system
-
-result = patient.fhirpath_single(
-    "Observation.code.subsumes(%parent)",
-    environment={
-        "%terminologyService": my_service,
-        "%parent": parent,
-    }
-)
-```
-
-!!! info "Fallback behaviour"
-
-    If the terminology service returns `None` for a subsumption query (e.g. the relationship is unknown), both `subsumes()` and `subsumedBy()` return an empty collection rather than `false`.
-

--- a/docs/user-guide/resources-models.md
+++ b/docs/user-guide/resources-models.md
@@ -239,7 +239,7 @@ Healthcare applications frequently need to convert data from external systems, A
 
 !!! danger "No Terminology Validation"
 
-    Fhircraft does not support validation of terminologies. This means that validation does not verify whether specific codes or CodeableConcepts are correct within the ValueSets or CodeSystems bound to the resource's elements.
+    Fhircraft does not validate terminologies by default. This means validation does not verify whether specific codes or CodeableConcepts are correct within the ValueSets or CodeSystems bound to the resource's elements unless you provide a terminology service for the relevant FHIRPath functions.
 
 ### Parsing FHIR JSON Files
 

--- a/fhircraft/config.py
+++ b/fhircraft/config.py
@@ -7,9 +7,12 @@ import os
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import FrozenSet, Generator, Literal, Container
+from typing import Container, FrozenSet, Generator, Literal
+
+from fhircraft.fhir.terminology import TerminologyService
 
 _VALID_MODES = ("strict", "lenient", "skip")
+_UNSET = object()
 
 
 @dataclass(frozen=True)
@@ -32,6 +35,9 @@ class FhircraftConfig:
     disable_fhir_errors: bool = False
     disabled_fhir_constraints: FrozenSet[str] = field(default_factory=frozenset)
     mode: Literal["strict", "lenient", "skip"] = "strict"
+    terminology_service: TerminologyService | None = field(
+        default=None, compare=False, hash=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         # Coerce mutable set to frozenset so the type contract is always satisfied
@@ -74,6 +80,7 @@ def configure(
     disable_fhir_errors: bool | None = None,
     disabled_fhir_constraints: Container[str] | None = None,
     validation_mode: Literal["strict", "lenient", "skip"] | None = None,
+    terminology_service: TerminologyService | None | object = _UNSET,
 ) -> None:
     """Configure FHIRcraft settings.
 
@@ -88,22 +95,20 @@ def configure(
         validation_mode: Validation mode - 'strict', 'lenient', or 'skip'.
     """
     current = get_config()
-    _config_context.set(
-        dataclasses.replace(
-            current,
-            **{
-                k: v
-                for k, v in {
-                    "disable_validation_warnings": disable_validation_warnings,
-                    "disable_fhir_warnings": disable_fhir_warnings,
-                    "disable_fhir_errors": disable_fhir_errors,
-                    "disabled_fhir_constraints": disabled_fhir_constraints,
-                    "mode": validation_mode,
-                }.items()
-                if v is not None
-            },
-        )
-    )
+    updates = {
+        k: v
+        for k, v in {
+            "disable_validation_warnings": disable_validation_warnings,
+            "disable_fhir_warnings": disable_fhir_warnings,
+            "disable_fhir_errors": disable_fhir_errors,
+            "disabled_fhir_constraints": disabled_fhir_constraints,
+            "mode": validation_mode,
+        }.items()
+        if v is not None
+    }
+    if terminology_service is not _UNSET:
+        updates["terminology_service"] = terminology_service
+    _config_context.set(dataclasses.replace(current, **updates))
 
 
 @contextmanager
@@ -114,6 +119,7 @@ def override_config(
     disable_fhir_errors: bool | None = None,
     disabled_fhir_constraints: Container[str] | None = None,
     validation_mode: Literal["strict", "lenient", "skip"] | None = None,
+    terminology_service: TerminologyService | None | object = _UNSET,
 ) -> Generator[FhircraftConfig, None, None]:
     """Context manager for temporary configuration changes.
 
@@ -132,19 +138,22 @@ def override_config(
         config (FhircraftConfig): The temporary configuration.
     """
     old_config = get_config()
+    updates = {
+        k: v
+        for k, v in {
+            "disable_validation_warnings": disable_validation_warnings,
+            "disable_fhir_warnings": disable_fhir_warnings,
+            "disable_fhir_errors": disable_fhir_errors,
+            "disabled_fhir_constraints": disabled_fhir_constraints,
+            "mode": validation_mode,
+        }.items()
+        if v is not None
+    }
+    if terminology_service is not _UNSET:
+        updates["terminology_service"] = terminology_service
     new_config = dataclasses.replace(
         old_config,
-        **{
-            k: v
-            for k, v in {
-                "disable_validation_warnings": disable_validation_warnings,
-                "disable_fhir_warnings": disable_fhir_warnings,
-                "disable_fhir_errors": disable_fhir_errors,
-                "disabled_fhir_constraints": disabled_fhir_constraints,
-                "mode": validation_mode,
-            }.items()
-            if v is not None
-        },
+        **updates,
     )
     token = _config_context.set(new_config)
     try:

--- a/fhircraft/fhir/path/engine/additional.py
+++ b/fhircraft/fhir/path/engine/additional.py
@@ -951,16 +951,13 @@ class MemberOf(FHIRPathFunction):
             version = codeable.coding[0].version
         else:
             return []
-        print(
-            f"Validating code '{code}' from system '{system}' against valueset '{self.valueset}' using terminology service."
-        )
         try:
             result = service.validate_valueset_code(
                 url=self.valueset, code=code, system=system, version=version
             )
         except Exception as e:
             warnings.warn(
-                f"Error validating code against valueset in memberOf() function: {e}. Skipping evaluation of memberOf().",
+                f"Error during terminology service call in memberOf() function: {e}. Skipping evaluation of memberOf().",
                 FhirPathWarning,
             )
             return []
@@ -977,11 +974,9 @@ class Subsumes(FHIRPathFunction):
         code (str): The code to check for subsumption.
     """
 
-    def __init__(self, code: str | Literal):
-        if isinstance(code, Literal):
-            code = code.value
-        if not isinstance(code, str):
-            raise FhirPathException("subsumes() argument must be a string.")
+    def __init__(self, code: FHIRPath):
+        if not isinstance(code, FHIRPath):
+            raise FhirPathException("subsumes() argument must be a FHIRPath instance.")
         self.code = code
 
     def evaluate(
@@ -1002,9 +997,59 @@ class Subsumes(FHIRPathFunction):
         Returns:
             collection (FHIRPathCollection): The output collection.
         """
-        raise NotImplementedError(
-            "Evaluation of the FHIRPath subsumes() function is not supported."
-        )
+        from fhircraft.fhir.resources.datatypes import utils as type_utils
+
+        if len(collection) != 1:
+            return []
+        service = _get_terminology_service(environment)
+        if service is None:
+            return []
+        release = environment.get("%fhirRelease")
+        if not release or not isinstance(release, str):
+            raise FhirPathException(
+                "The %fhirRelease environment variable is required for evaluating memberOf()."
+            )
+        codingB = self.code.single(collection, environment=environment)
+        if type_utils.is_fhir_complex_type(codingB, "CodeableConcept", release):
+            if len(codingB.coding) == 0:
+                raise FhirPathException(
+                    "The code argument to subsumes() cannot be an empty CodeableConcept."
+                )
+            codingB = codingB.coding[0]
+        elif not type_utils.is_fhir_complex_type(codingB, "Coding", release):
+            raise FhirPathException(
+                "The code argument to subsumes() must be a Coding or CodeableConcept."
+            )
+
+        codingA = collection[0].value
+        if type_utils.is_fhir_complex_type(codingA, "CodeableConcept", release):
+            if len(codingA.coding) == 0:
+                raise FhirPathException(
+                    "The code argument to subsumes() cannot be an empty CodeableConcept."
+                )
+            codingA = codingA.coding[0]
+        elif not type_utils.is_fhir_complex_type(codingA, "Coding", release):
+            return []
+        if codingA.system != codingB.system:
+            raise FhirPathException(
+                f"Subsumption across different code systems is not a valid operation. Attempting to subsume between code systems '{codingA.system}' and '{codingB.system}'."
+            )
+        try:
+            result = service.codesystem_subsumes(
+                codeA=codingA,
+                codeB=codingB,
+                system=codingA.system,
+                version=codingA.version,
+            )
+        except Exception as e:
+            warnings.warn(
+                f"Error during terminology service call in subsumes() function: {e}. Skipping evaluation of subsumes().",
+                FhirPathWarning,
+            )
+            return []
+        if result is None:
+            return []
+        return [FHIRPathCollectionItem.wrap(bool(result))]
 
 
 class SubsumedBy(FHIRPathFunction):

--- a/fhircraft/fhir/path/engine/additional.py
+++ b/fhircraft/fhir/path/engine/additional.py
@@ -966,12 +966,82 @@ class MemberOf(FHIRPathFunction):
         return [FHIRPathCollectionItem.wrap(bool(result))]
 
 
+def _evaluate_subsumtion(code, collection, environment, create, invert=False):
+    """
+    Helper function to evaluate subsumption relationships for both subsumes() and subsumedBy() functions.
+    """
+    from fhircraft.fhir.resources.datatypes import utils as type_utils
+
+    if len(collection) != 1:
+        return []
+    service = _get_terminology_service(environment)
+    if service is None:
+        return []
+    release = environment.get("%fhirRelease")
+    if not release or not isinstance(release, str):
+        raise FhirPathException(
+            f"The %fhirRelease environment variable is required for evaluating {'subsumes()' if not invert else 'subsumedBy()'}."
+        )
+    given = code.evaluate(collection, environment=environment, create=create)
+    if len(given) != 1:
+        return []
+    given = given[0].value
+    if type_utils.is_fhir_complex_type(given, "Coding", release):
+        codingsB = [given]
+    elif type_utils.is_fhir_complex_type(given, "CodeableConcept", release):
+        if len(given.coding) == 0:
+            raise FhirPathException(
+                f"The code argument to {'subsumes()' if not invert else 'subsumedBy()'} cannot be an empty CodeableConcept."
+            )
+        codingsB = given.coding
+    else:
+        raise FhirPathException(
+            f"The code argument to {'subsumes()' if not invert else 'subsumedBy()'} must be a Coding or CodeableConcept."
+        )
+
+    source = collection[0].value
+    if type_utils.is_fhir_complex_type(source, "CodeableConcept", release):
+        if len(source.coding) == 0:
+            raise FhirPathException(
+                f"The source collection in {'subsumes()' if not invert else 'subsumedBy()'} cannot be an empty CodeableConcept."
+            )
+        codingsA = source.coding
+    elif type_utils.is_fhir_complex_type(source, "Coding", release):
+        codingsA = [source]
+    else:
+        return []
+    for codingA in codingsA:
+        for codingB in codingsB:
+            if codingA.system != codingB.system:
+                raise FhirPathException(
+                    f"Subsumption across different code systems is not a valid operation. Attempting to subsume between code systems '{codingA.system}' and '{codingB.system}'."
+                )
+            try:
+                result = service.codesystem_subsumes(
+                    codeA=codingA if not invert else codingB,
+                    codeB=codingB if not invert else codingA,
+                    system=codingA.system,
+                    version=codingA.version,
+                )
+            except Exception as e:
+                warnings.warn(
+                    f"Error during terminology service call in {'subsumes()' if not invert else 'subsumedBy()'} function: {e}. Skipping evaluation of {'subsumes()' if not invert else 'subsumedBy()'}.",
+                    FhirPathWarning,
+                )
+                return []
+            if result is None:
+                return []
+            if result is True:
+                return [FHIRPathCollectionItem.wrap(bool(True))]
+    return [FHIRPathCollectionItem.wrap(bool(False))]
+
+
 class Subsumes(FHIRPathFunction):
     """
     A representation of the FHIRPath [`subsumes()`](https://www.hl7.org/fhir/fhirpath.html) function.
 
     Attributes:
-        code (str): The code to check for subsumption.
+        code (FHIRPath): The code to check for subsumption.
     """
 
     def __init__(self, code: FHIRPath):
@@ -997,59 +1067,13 @@ class Subsumes(FHIRPathFunction):
         Returns:
             collection (FHIRPathCollection): The output collection.
         """
-        from fhircraft.fhir.resources.datatypes import utils as type_utils
-
-        if len(collection) != 1:
-            return []
-        service = _get_terminology_service(environment)
-        if service is None:
-            return []
-        release = environment.get("%fhirRelease")
-        if not release or not isinstance(release, str):
-            raise FhirPathException(
-                "The %fhirRelease environment variable is required for evaluating memberOf()."
-            )
-        codingB = self.code.single(collection, environment=environment)
-        if type_utils.is_fhir_complex_type(codingB, "CodeableConcept", release):
-            if len(codingB.coding) == 0:
-                raise FhirPathException(
-                    "The code argument to subsumes() cannot be an empty CodeableConcept."
-                )
-            codingB = codingB.coding[0]
-        elif not type_utils.is_fhir_complex_type(codingB, "Coding", release):
-            raise FhirPathException(
-                "The code argument to subsumes() must be a Coding or CodeableConcept."
-            )
-
-        codingA = collection[0].value
-        if type_utils.is_fhir_complex_type(codingA, "CodeableConcept", release):
-            if len(codingA.coding) == 0:
-                raise FhirPathException(
-                    "The code argument to subsumes() cannot be an empty CodeableConcept."
-                )
-            codingA = codingA.coding[0]
-        elif not type_utils.is_fhir_complex_type(codingA, "Coding", release):
-            return []
-        if codingA.system != codingB.system:
-            raise FhirPathException(
-                f"Subsumption across different code systems is not a valid operation. Attempting to subsume between code systems '{codingA.system}' and '{codingB.system}'."
-            )
-        try:
-            result = service.codesystem_subsumes(
-                codeA=codingA,
-                codeB=codingB,
-                system=codingA.system,
-                version=codingA.version,
-            )
-        except Exception as e:
-            warnings.warn(
-                f"Error during terminology service call in subsumes() function: {e}. Skipping evaluation of subsumes().",
-                FhirPathWarning,
-            )
-            return []
-        if result is None:
-            return []
-        return [FHIRPathCollectionItem.wrap(bool(result))]
+        return _evaluate_subsumtion(
+            code=self.code,
+            collection=collection,
+            environment=environment,
+            create=create,
+            invert=False,
+        )
 
 
 class SubsumedBy(FHIRPathFunction):
@@ -1057,14 +1081,14 @@ class SubsumedBy(FHIRPathFunction):
     A representation of the FHIRPath [`subsumedBy()`](https://www.hl7.org/fhir/fhirpath.html) function.
 
     Attributes:
-        code (str): The code to check for subsumption.
+        code (FHIRPath): The code to check for subsumption.
     """
 
-    def __init__(self, code: str | Literal):
-        if isinstance(code, Literal):
-            code = code.value
-        if not isinstance(code, str):
-            raise FhirPathException("subsumedBy() argument must be a string.")
+    def __init__(self, code: FHIRPath):
+        if not isinstance(code, FHIRPath):
+            raise FhirPathException(
+                "subsumedBy() argument must be a FHIRPath instance."
+            )
         self.code = code
 
     def evaluate(
@@ -1087,8 +1111,12 @@ class SubsumedBy(FHIRPathFunction):
         Returns:
             collection (FHIRPathCollection): The output collection.
         """
-        raise NotImplementedError(
-            "Evaluation of the FHIRPath subsumes() function is not supported."
+        return _evaluate_subsumtion(
+            code=self.code,
+            collection=collection,
+            environment=environment,
+            create=create,
+            invert=True,
         )
 
 

--- a/fhircraft/fhir/path/engine/additional.py
+++ b/fhircraft/fhir/path/engine/additional.py
@@ -867,6 +867,8 @@ class ConformsTo(FHIRPathFunction):
         if len(collection) != 1:
             return []
         fhir_release: None = environment.get("%fhirRelease")
+        if isinstance(fhir_release, FHIRPathCollectionItem):
+            fhir_release = fhir_release.value
         if not fhir_release or not isinstance(fhir_release, str):
             raise FhirPathException(
                 "The %fhirRelease environment variable is required for evaluating conformsTo()."
@@ -931,6 +933,9 @@ class MemberOf(FHIRPathFunction):
         if service is None:
             return []
         release = environment.get("%fhirRelease")
+        if isinstance(release, FHIRPathCollectionItem):
+            release = release.value
+
         if not release or not isinstance(release, str):
             raise FhirPathException(
                 "The %fhirRelease environment variable is required for evaluating memberOf()."
@@ -978,6 +983,8 @@ def _evaluate_subsumtion(code, collection, environment, create, invert=False):
     if service is None:
         return []
     release = environment.get("%fhirRelease")
+    if isinstance(release, FHIRPathCollectionItem):
+        release = release.value
     if not release or not isinstance(release, str):
         raise FhirPathException(
             f"The %fhirRelease environment variable is required for evaluating {'subsumes()' if not invert else 'subsumedBy()'}."

--- a/fhircraft/fhir/path/engine/additional.py
+++ b/fhircraft/fhir/path/engine/additional.py
@@ -795,9 +795,11 @@ class Slice(FHIRPathFunction):
         Returns:
             collection (FHIRPathCollection): The output collection.
         """
-        raise NotImplementedError(
-            "Evaluation of the FHIRPath slice() function is not supported."
+        warnings.warn(
+            "Evaluation of the FHIRPath slice() function is not supported. Returning an empty collection.",
+            FhirPathWarning,
         )
+        return []
 
 
 class CheckModifiers(FHIRPathFunction):

--- a/fhircraft/fhir/path/engine/additional.py
+++ b/fhircraft/fhir/path/engine/additional.py
@@ -9,6 +9,8 @@ import sys
 from html.parser import HTMLParser
 from xml.etree import ElementTree as ET
 from pydantic import ValidationError
+from typing import Callable
+from fhircraft.config import get_config
 from fhircraft.fhir.path.engine.core import (
     Element,
     FHIRPath,
@@ -23,11 +25,19 @@ from fhircraft.fhir.path.engine.equality import Equals
 from fhircraft.fhir.path.engine.filtering import Where
 from fhircraft.fhir.path.engine.environment import EnvironmentVariable
 from fhircraft.fhir.path.engine.literals import Date, DateTime, Quantity, Time
+from fhircraft.fhir.terminology import TerminologyService
 from fhircraft.fhir.resources.datatypes.registry import get_fhir_type_by_url
 from fhircraft.fhir.resources.definitions.registry import StructureDefinitionRegistry
 from fhircraft.utils import ensure_list
 from fhircraft.fhir.resources.datatypes.utils import is_fhir_primitive
 from fhircraft.exceptions import FhirPathWarning
+
+
+def _get_terminology_service(environment: dict) -> TerminologyService | None:
+    service = environment.get("%terminologyService")
+    if service is not None:
+        return service
+    return get_config().terminology_service
 
 
 class Extension(FHIRPathFunction):
@@ -913,9 +923,50 @@ class MemberOf(FHIRPathFunction):
         Returns:
             collection (FHIRPathCollection): The output collection.
         """
-        raise NotImplementedError(
-            "Evaluation of the FHIRPath memberOf() function is not supported."
+        from fhircraft.fhir.resources.datatypes import utils as type_utils
+
+        if len(collection) != 1:
+            return []
+        service = _get_terminology_service(environment)
+        if service is None:
+            return []
+        release = environment.get("%fhirRelease")
+        if not release or not isinstance(release, str):
+            raise FhirPathException(
+                "The %fhirRelease environment variable is required for evaluating memberOf()."
+            )
+        codeable = collection[0].value
+        if isinstance(codeable, str):
+            code = codeable
+            system, version = None, None
+        elif type_utils.is_fhir_complex_type(codeable, "Coding", release):
+            code = codeable.code
+            system = codeable.system
+            version = codeable.version
+        elif type_utils.is_fhir_complex_type(codeable, "CodeableConcept", release):
+            if len(codeable.coding) == 0:
+                return []
+            code = codeable.coding[0].code
+            system = codeable.coding[0].system
+            version = codeable.coding[0].version
+        else:
+            return []
+        print(
+            f"Validating code '{code}' from system '{system}' against valueset '{self.valueset}' using terminology service."
         )
+        try:
+            result = service.validate_valueset_code(
+                url=self.valueset, code=code, system=system, version=version
+            )
+        except Exception as e:
+            warnings.warn(
+                f"Error validating code against valueset in memberOf() function: {e}. Skipping evaluation of memberOf().",
+                FhirPathWarning,
+            )
+            return []
+        if result is None:
+            return []
+        return [FHIRPathCollectionItem.wrap(bool(result))]
 
 
 class Subsumes(FHIRPathFunction):

--- a/fhircraft/fhir/path/engine/additional.py
+++ b/fhircraft/fhir/path/engine/additional.py
@@ -8,7 +8,7 @@ import re
 import sys
 from html.parser import HTMLParser
 from xml.etree import ElementTree as ET
-
+from pydantic import ValidationError
 from fhircraft.fhir.path.engine.core import (
     Element,
     FHIRPath,
@@ -23,6 +23,8 @@ from fhircraft.fhir.path.engine.equality import Equals
 from fhircraft.fhir.path.engine.filtering import Where
 from fhircraft.fhir.path.engine.environment import EnvironmentVariable
 from fhircraft.fhir.path.engine.literals import Date, DateTime, Quantity, Time
+from fhircraft.fhir.resources.datatypes.registry import get_fhir_type_by_url
+from fhircraft.fhir.resources.definitions.registry import StructureDefinitionRegistry
 from fhircraft.utils import ensure_list
 from fhircraft.fhir.resources.datatypes.utils import is_fhir_primitive
 from fhircraft.exceptions import FhirPathWarning
@@ -852,9 +854,28 @@ class ConformsTo(FHIRPathFunction):
         Returns:
             collection (FHIRPathCollection): The output collection.
         """
-        raise NotImplementedError(
-            "Evaluation of the FHIRPath conformsTo() function is not supported."
-        )
+        if len(collection) != 1:
+            return []
+        fhir_release: None = environment.get("%fhirRelease")
+        if not fhir_release or not isinstance(fhir_release, str):
+            raise FhirPathException(
+                "The %fhirRelease environment variable is required for evaluating conformsTo()."
+            )
+        try:
+            get_fhir_type_by_url(
+                self.structure, release=fhir_release, fail_if_not_found=True
+            ).model_validate(collection[0].value)
+        except AttributeError:
+            warnings.warn(
+                f"Could not resolve structure definition '{self.structure}' for conformsTo() function."
+                f" Current implementation is limited to core resources. Returning empty result.",
+                FhirPathWarning,
+            )
+            return []
+        except ValidationError as e:
+            print(f"Validation error during conformsTo() evaluation: {e}")
+            return [FHIRPathCollectionItem.wrap(False)]
+        return [FHIRPathCollectionItem.wrap(True)]
 
 
 class MemberOf(FHIRPathFunction):

--- a/fhircraft/fhir/resources/datatypes/registry.py
+++ b/fhircraft/fhir/resources/datatypes/registry.py
@@ -274,13 +274,13 @@ def get_fhir_type(
 
 @overload
 def get_fhir_type_by_url(
-    url: str, release, fail_if_not_found: Literal[True] = True
+    url: str, release: str, fail_if_not_found: Literal[True] = True
 ) -> type[FHIRBaseModel]: ...
 
 
 @overload
 def get_fhir_type_by_url(
-    url: str, release, fail_if_not_found: Literal[False] = False
+    url: str, release: str, fail_if_not_found: Literal[False] = False
 ) -> type[FHIRBaseModel] | None: ...
 
 

--- a/fhircraft/fhir/terminology.py
+++ b/fhircraft/fhir/terminology.py
@@ -1,0 +1,99 @@
+"""Terminology service abstractions for FHIRcraft."""
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TerminologyService(Protocol):
+    """Pluggable terminology service used by FHIRPath terminology functions."""
+
+    def codesystem_lookup(
+        self,
+        *,
+        code: str,
+        system: str | None = None,
+        version: str | None = None,
+    ) -> Any:
+        """
+        Implements the CodeSystem/$lookup operation.
+
+        Given a code/system, or a Coding, get additional details about the concept,
+        including definition, status, designations, and properties. One of the products
+        of this operation is a full decomposition of a code from a structured terminology.
+
+        Args:
+            code: The code to look up.
+            system: The code system the code belongs to (optional if the code is unique across all systems).
+            version: The version of the code system to look up (optional).
+        """
+        ...
+
+    def validate_valueset_code(
+        self,
+        *,
+        url: str | None = None,
+        code: str | None = None,
+        system: str | None = None,
+        version: str | None = None,
+        display: str | None = None,
+    ) -> bool:
+        """
+        Implements the ValueSet/$validate-code operation.
+
+        Validate that a coded value is in the set of codes allowed by a valueset.
+
+        Args:
+            url: The URL of the valueset to validate against.
+            code: The code to validate.
+            system: The system of the code to validate.
+            version: The version of the code system or value set to validate against.
+            display: The display string to validate (optional).
+        """
+        ...
+
+    def validate_codesystem_code(
+        self,
+        *,
+        url: str | None = None,
+        code: str | None = None,
+        version: str | None = None,
+        display: str | None = None,
+    ) -> bool:
+        """
+        Implements the CodeSystem/$validate-code operation.
+
+        Validate that a coded value is in the set of codes allowed by a codesystem.
+
+        Args:
+            url: The URL of the codesystem to validate against.
+            code: The code to validate.
+            version: The version of the codesystem to validate against.
+            display: The display string to validate (optional).
+        """
+        ...
+
+    def codesystem_subsumes(
+        self,
+        codeA: str,
+        codeB: str,
+        system: str | None = None,
+        version: str | None = None,
+    ) -> bool | None:
+        """
+        Implements the CodeSystem/$subsumes operation.
+
+        Determine if one code is subsumed by another within a code system.
+
+        Args:
+            codeA: The first code to compare.
+            codeB: The second code to compare.
+            system: The code system the codes belong to (optional if the codes are unique across all systems).
+            version: The version of the code system to use for comparison (optional).
+
+        Returns:
+            True if the source code subsumes the target code, False if not, or None if unknown.
+        """
+        ...
+
+
+__all__ = ["TerminologyService"]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -14,6 +14,27 @@ from fhircraft.config import (
 from fhircraft.fhir.resources.validators import (
     _validate_FHIR_element_constraint,
 )
+from fhircraft.fhir.terminology import TerminologyService
+
+
+class _StubTerminologyService:
+    """Minimal structural implementation of TerminologyService for config tests."""
+
+    def codesystem_lookup(self, *, code, system=None, version=None):
+        return None
+
+    def validate_valueset_code(
+        self, *, url=None, code=None, system=None, version=None, display=None
+    ):
+        return False
+
+    def validate_codesystem_code(
+        self, *, url=None, code=None, version=None, display=None
+    ):
+        return False
+
+    def codesystem_subsumes(self, codeA, codeB, system=None, version=None):
+        return None
 
 
 @pytest.fixture(autouse=True)
@@ -305,6 +326,76 @@ def test_load_with_no_env_vars():
     # Should not raise any errors
     load_config_from_env()
     assert get_config().mode == "strict"
+
+
+# =========================================================================
+# Terminology_service configuration
+# =========================================================================
+
+
+def test_default_config_terminology_service_is_none():
+    assert get_config().terminology_service is None
+
+
+def test_configure__sets_terminology_service():
+    stub = _StubTerminologyService()
+    configure(terminology_service=stub)
+    assert get_config().terminology_service is stub
+
+
+def test_configure__clears_terminology_service_with_none():
+    stub = _StubTerminologyService()
+    configure(terminology_service=stub)
+    assert get_config().terminology_service is stub
+
+    configure(terminology_service=None)
+    assert get_config().terminology_service is None
+
+
+def test_configure__omitting_terminology_service_preserves_existing():
+    stub = _StubTerminologyService()
+    configure(terminology_service=stub)
+
+    # Call configure() for an unrelated setting — service must survive
+    configure(disable_validation_warnings=True)
+
+    assert get_config().terminology_service is stub
+
+
+def test_override_config__terminology_service_restored():
+    stub = _StubTerminologyService()
+
+    with override_config(terminology_service=stub):
+        assert get_config().terminology_service is stub
+
+    assert get_config().terminology_service is None
+
+
+def test_override_config__clears_terminology_service_within_context():
+    stub = _StubTerminologyService()
+    configure(terminology_service=stub)
+
+    with override_config(terminology_service=None):
+        assert get_config().terminology_service is None
+
+    # Restored after context
+    assert get_config().terminology_service is stub
+
+
+def test_override_config__omitting_terminology_service_preserves_existing():
+    stub = _StubTerminologyService()
+    configure(terminology_service=stub)
+
+    with override_config(disable_validation_warnings=True):
+        assert get_config().terminology_service is stub
+
+    assert get_config().terminology_service is stub
+
+
+def test_terminology_service_isinstance_check():
+    # TerminologyService is @runtime_checkable; structural implementations must pass
+    stub = _StubTerminologyService()
+    assert isinstance(stub, TerminologyService)
 
 
 # =========================================================================

--- a/test/test_fhir_path_engine_additional.py
+++ b/test/test_fhir_path_engine_additional.py
@@ -852,7 +852,7 @@ def test_subsumes_raises_error_when_fhir_release_not_in_environment(
             value=R4_Coding(system="http://loinc.org", code="parent")
         )
     ]
-    with pytest.raises(FhirPathException, match="required for evaluating memberOf"):
+    with pytest.raises(FhirPathException, match="required for evaluating subsumes"):
         Subsumes(EnvironmentVariable("%otherCoding")).evaluate(
             collection,
             {
@@ -878,6 +878,102 @@ def test_subsumes_raises_error_for_different_code_systems(terminology_service):
                 "%terminologyService": terminology_service,
                 "%otherCoding": R4_Coding(
                     system="http://snomed.info/sct", code="child"
+                ),
+            },
+        )
+
+
+# -------------
+# SubsumedBy
+# -------------
+
+
+def test_subsumedby_returns_empty_for_empty_collection():
+    collection = []
+    result = SubsumedBy(Element("example-code")).evaluate(collection, env)
+    assert result == []
+
+
+def test_subsumedby_returns_true_for_subsumed_code(terminology_service):
+    collection = [
+        FHIRPathCollectionItem(value=R4_Coding(system="http://loinc.org", code="child"))
+    ]
+    result = SubsumedBy(EnvironmentVariable("%otherCoding")).evaluate(
+        collection,
+        {
+            "%fhirRelease": "R4",
+            "%terminologyService": terminology_service,
+            "%otherCoding": R4_Coding(system="http://loinc.org", code="parent"),
+        },
+    )
+    assert result[0].value == True
+
+
+def test_subsumedby_returns_false_for_non_subsumed_code(terminology_service):
+    collection = [
+        FHIRPathCollectionItem(
+            value=R4_Coding(system="http://loinc.org", code="parent")
+        )
+    ]
+    result = SubsumedBy(EnvironmentVariable("%otherCoding")).evaluate(
+        collection,
+        {
+            "%fhirRelease": "R4",
+            "%terminologyService": terminology_service,
+            "%otherCoding": R4_Coding(system="http://loinc.org", code="child"),
+        },
+    )
+    assert result[0].value == False
+
+
+def test_subsumedby_returns_empty_when_service_returns_none(terminology_service):
+    collection = [
+        FHIRPathCollectionItem(
+            value=R4_Coding(system="http://loinc.org", code="unknown")
+        )
+    ]
+    result = SubsumedBy(EnvironmentVariable("%otherCoding")).evaluate(
+        collection,
+        {
+            "%fhirRelease": "R4",
+            "%terminologyService": terminology_service,
+            "%otherCoding": R4_Coding(system="http://loinc.org", code="child"),
+        },
+    )
+    assert result == []
+
+
+def test_subsumedby_raises_error_when_fhir_release_not_in_environment(
+    terminology_service,
+):
+    collection = [
+        FHIRPathCollectionItem(value=R4_Coding(system="http://loinc.org", code="child"))
+    ]
+    with pytest.raises(FhirPathException, match="required for evaluating"):
+        SubsumedBy(EnvironmentVariable("%otherCoding")).evaluate(
+            collection,
+            {
+                "%terminologyService": terminology_service,
+                "%otherCoding": R4_Coding(system="http://loinc.org", code="parent"),
+            },
+        )
+
+
+def test_subsumedby_raises_error_for_different_code_systems(terminology_service):
+    collection = [
+        FHIRPathCollectionItem(value=R4_Coding(system="http://loinc.org", code="child"))
+    ]
+    with pytest.raises(
+        FhirPathException,
+        match="Subsumption across different code systems",
+    ):
+        SubsumedBy(EnvironmentVariable("%otherCoding")).evaluate(
+            collection,
+            {
+                "%fhirRelease": "R4",
+                "%terminologyService": terminology_service,
+                "%otherCoding": R4_Coding(
+                    system="http://snomed.info/sct", code="parent"
                 ),
             },
         )

--- a/test/test_fhir_path_engine_additional.py
+++ b/test/test_fhir_path_engine_additional.py
@@ -37,6 +37,10 @@ def terminology_service():
 
     class MockTerminologyService(TerminologyService):
 
+        @staticmethod
+        def _code_value(code):
+            return getattr(code, "code", code)
+
         def validate_valueset_code(self, *, url=None, code=None, **kwargs):
             if url == "http://example.org/ValueSet/ExampleVS":
                 if code == "valid-code":
@@ -52,7 +56,19 @@ def terminology_service():
             raise NotImplementedError()
 
         def codesystem_subsumes(self, codeA, codeB, system=None, version=None):
-            raise NotImplementedError()
+            code_a = self._code_value(codeA)
+            code_b = self._code_value(codeB)
+            if system is None:
+                raise ValueError("system is required")
+            if code_a == "parent" and code_b == "child":
+                return True
+            if code_a == "child" and code_b == "parent":
+                return False
+            if code_a == "unknown" or code_b == "unknown":
+                return None
+            if code_a == "error":
+                raise RuntimeError("terminology backend error")
+            return False
 
     return MockTerminologyService()
 
@@ -731,7 +747,7 @@ def test_memberof_returns_true_for_valid_codeableconcept(terminology_service):
 def test_memberof_returns_empty_for_unresolvable_valueset(terminology_service):
     collection = [FHIRPathCollectionItem(value="valid-code")]
     with pytest.warns(
-        FhirPathWarning, match="Error validating code against valueset in memberOf()"
+        FhirPathWarning, match="Error during terminology service call in memberOf()"
     ):
         result = MemberOf("http://example.org/ValueSet/Unknown").evaluate(
             collection,
@@ -747,4 +763,121 @@ def test_memberof_raises_error_when_fhir_release_not_in_environment(
     with pytest.raises(FhirPathException, match="required for evaluating memberOf"):
         MemberOf("http://example.org/ValueSet/ExampleVS").evaluate(
             collection, {"%terminologyService": terminology_service}
+        )
+
+
+# -------------
+# Subsumes
+# -------------
+
+
+def test_subsumes_returns_empty_for_empty_collection():
+    collection = []
+    result = Subsumes(Element("example-code")).evaluate(collection, env)
+    assert result == []
+
+
+def test_subsumes_returns_true_for_subsuming_code(terminology_service):
+    collection = [
+        FHIRPathCollectionItem(
+            value=R4_Coding(system="http://loinc.org", code="parent")
+        )
+    ]
+    result = Subsumes(EnvironmentVariable("%otherCoding")).evaluate(
+        collection,
+        {
+            "%fhirRelease": "R4",
+            "%terminologyService": terminology_service,
+            "%otherCoding": R4_Coding(system="http://loinc.org", code="child"),
+        },
+    )
+    assert result[0].value == True
+
+
+def test_subsumes_returns_false_for_non_subsuming_code(terminology_service):
+    collection = [
+        FHIRPathCollectionItem(value=R4_Coding(system="http://loinc.org", code="child"))
+    ]
+    result = Subsumes(EnvironmentVariable("%otherCoding")).evaluate(
+        collection,
+        {
+            "%fhirRelease": "R4",
+            "%terminologyService": terminology_service,
+            "%otherCoding": R4_Coding(system="http://loinc.org", code="parent"),
+        },
+    )
+    assert result[0].value == False
+
+
+def test_subsumes_returns_empty_when_service_returns_none(terminology_service):
+    collection = [
+        FHIRPathCollectionItem(
+            value=R4_Coding(system="http://loinc.org", code="unknown")
+        )
+    ]
+    result = Subsumes(EnvironmentVariable("%otherCoding")).evaluate(
+        collection,
+        {
+            "%fhirRelease": "R4",
+            "%terminologyService": terminology_service,
+            "%otherCoding": R4_Coding(system="http://loinc.org", code="child"),
+        },
+    )
+    assert result == []
+
+
+def test_subsumes_warns_and_returns_empty_when_service_raises(terminology_service):
+    collection = [
+        FHIRPathCollectionItem(value=R4_Coding(system="http://loinc.org", code="error"))
+    ]
+    with pytest.warns(
+        FhirPathWarning, match="Error during terminology service call in subsumes()"
+    ):
+        result = Subsumes(EnvironmentVariable("%otherCoding")).evaluate(
+            collection,
+            {
+                "%fhirRelease": "R4",
+                "%terminologyService": terminology_service,
+                "%otherCoding": R4_Coding(system="http://loinc.org", code="child"),
+            },
+        )
+    assert result == []
+
+
+def test_subsumes_raises_error_when_fhir_release_not_in_environment(
+    terminology_service,
+):
+    collection = [
+        FHIRPathCollectionItem(
+            value=R4_Coding(system="http://loinc.org", code="parent")
+        )
+    ]
+    with pytest.raises(FhirPathException, match="required for evaluating memberOf"):
+        Subsumes(EnvironmentVariable("%otherCoding")).evaluate(
+            collection,
+            {
+                "%terminologyService": terminology_service,
+                "%otherCoding": R4_Coding(system="http://loinc.org", code="child"),
+            },
+        )
+
+
+def test_subsumes_raises_error_for_different_code_systems(terminology_service):
+    collection = [
+        FHIRPathCollectionItem(
+            value=R4_Coding(system="http://loinc.org", code="parent")
+        )
+    ]
+    with pytest.raises(
+        FhirPathException, match="Subsumption across different code systems"
+    ):
+        Subsumes(EnvironmentVariable("%otherCoding")).evaluate(
+            collection,
+            {
+                "%fhirRelease": "R4",
+                "%terminologyService": terminology_service,
+                "%otherCoding": R4_Coding(
+                    system="http://snomed.info/sct", code="child"
+                ),
+            },
         )

--- a/test/test_fhir_path_engine_additional.py
+++ b/test/test_fhir_path_engine_additional.py
@@ -561,3 +561,65 @@ def test_resolve_with_unresolvable_internal_reference():
     collection = [FHIRPathCollectionItem(value="#1234")]
     result = Resolve().evaluate(collection, {"%resource": resource})
     assert result == []
+
+
+# -------------
+# ConformsTo
+# -------------
+
+
+def test_conformsto_returns_empty_for_empty_collection():
+    collection = []
+    result = ConformsTo("http://hl7.org/fhir/StructureDefinition/Patient").evaluate(
+        collection, env
+    )
+    assert result == []
+
+
+def test_conformsto_returns_empty_for_non_singleton_collection():
+    collection = [FHIRPathCollectionItem(value=1), FHIRPathCollectionItem(value=2)]
+    result = ConformsTo("http://hl7.org/fhir/StructureDefinition/Patient").evaluate(
+        collection, env
+    )
+    assert result == []
+
+
+def test_conformsto_raises_error_when_fhir_release_not_in_environment():
+    collection = [FHIRPathCollectionItem(value={"resourceType": "Patient"})]
+    with pytest.raises(FhirPathException, match="required for evaluating conformsTo"):
+        ConformsTo("http://hl7.org/fhir/StructureDefinition/Patient").evaluate(
+            collection, {}
+        )
+
+
+def test_conformsto_returns_true_for_conforming_resource():
+    collection = [
+        FHIRPathCollectionItem(value={"resourceType": "Patient", "gender": "female"})
+    ]
+    result = ConformsTo("http://hl7.org/fhir/StructureDefinition/Patient").evaluate(
+        collection, {"%fhirRelease": "R4"}
+    )
+    assert result[0].value == True
+
+
+def test_conformsto_returns_false_for_non_conforming_resource():
+    collection = [
+        FHIRPathCollectionItem(
+            value={"resourceType": "Observation", "valueCode": "female"}
+        )
+    ]
+    result = ConformsTo("http://hl7.org/fhir/StructureDefinition/Patient").evaluate(
+        collection, {"%fhirRelease": "R4"}
+    )
+    assert result[0].value == False
+
+
+def test_conformsto_returns_empty_for_unresolvable_structure_definition():
+    collection = [
+        FHIRPathCollectionItem(value={"resourceType": "Patient", "gender": "female"})
+    ]
+    with pytest.warns(FhirPathWarning, match="Could not resolve structure definition"):
+        result = ConformsTo("http://example.org/StructureDefinition/Unknown").evaluate(
+            collection, {"%fhirRelease": "R4"}
+        )
+    assert result == []

--- a/test/test_fhir_path_engine_additional.py
+++ b/test/test_fhir_path_engine_additional.py
@@ -10,6 +10,8 @@ from fhircraft.fhir.path.engine.literals import Date, DateTime
 from fhircraft.fhir.resources.base import FHIRPrimitiveModel
 from fhircraft.fhir.resources.datatypes import get_fhir_type
 from fhircraft.fhir.resources.datatypes.R4.complex import (
+    Coding as R4_Coding,
+    CodeableConcept as R4_CodeableConcept,
     Quantity as R4_Quantity,
     Age as R4_Age,
     Extension as R4_Extension,
@@ -27,6 +29,33 @@ from fhircraft.fhir.resources.datatypes.R5.complex import (
 from fhircraft.fhir.resources.datatypes.R5.primitive.integer import Integer
 
 env = dict()
+
+
+@pytest.fixture
+def terminology_service():
+    """Fixture that provides a mock terminology service implementation for testing."""
+
+    class MockTerminologyService(TerminologyService):
+
+        def validate_valueset_code(self, *, url=None, code=None, **kwargs):
+            if url == "http://example.org/ValueSet/ExampleVS":
+                if code == "valid-code":
+                    return True
+                else:
+                    return False
+            raise ValueError()
+
+        def validate_codesystem_code(self, **kwargs):
+            raise NotImplementedError()
+
+        def codesystem_lookup(self, **kwargs):
+            raise NotImplementedError()
+
+        def codesystem_subsumes(self, codeA, codeB, system=None, version=None):
+            raise NotImplementedError()
+
+    return MockTerminologyService()
+
 
 # -------------
 # Extension
@@ -623,3 +652,99 @@ def test_conformsto_returns_empty_for_unresolvable_structure_definition():
             collection, {"%fhirRelease": "R4"}
         )
     assert result == []
+
+
+# -------------
+# MemberOf
+# -------------
+
+
+def test_memberof_returns_empty_for_empty_collection():
+    collection = []
+    result = MemberOf("http://example.org/ValueSet/ExampleVS").evaluate(collection, env)
+    assert result == []
+
+
+def test_memberof_returns_false_for_invalid_code(terminology_service):
+    collection = [FHIRPathCollectionItem(value="invalid-code")]
+    result = MemberOf("http://example.org/ValueSet/ExampleVS").evaluate(
+        collection,
+        {"%fhirRelease": "R4", "%terminologyService": terminology_service},
+    )
+    assert result[0].value == False
+
+
+def test_memberof_returns_false_for_invalid_coding(terminology_service):
+    collection = [FHIRPathCollectionItem(value=R4_Coding(code="invalid-code"))]
+    result = MemberOf("http://example.org/ValueSet/ExampleVS").evaluate(
+        collection,
+        {"%fhirRelease": "R4", "%terminologyService": terminology_service},
+    )
+    assert result[0].value == False
+
+
+def test_memberof_returns_false_for_invalid_codeableconcept(terminology_service):
+    collection = [
+        FHIRPathCollectionItem(
+            value=R4_CodeableConcept(coding=[R4_Coding(code="invalid-code")])
+        )
+    ]
+    result = MemberOf("http://example.org/ValueSet/ExampleVS").evaluate(
+        collection,
+        {"%fhirRelease": "R4", "%terminologyService": terminology_service},
+    )
+    assert result[0].value == False
+
+
+def test_memberof_returns_true_for_valid_code(terminology_service):
+    collection = [FHIRPathCollectionItem(value="valid-code")]
+
+    result = MemberOf("http://example.org/ValueSet/ExampleVS").evaluate(
+        collection,
+        {"%fhirRelease": "R4", "%terminologyService": terminology_service},
+    )
+    assert result[0].value == True
+
+
+def test_memberof_returns_true_for_valid_coding(terminology_service):
+    collection = [FHIRPathCollectionItem(value=R4_Coding(code="valid-code"))]
+    result = MemberOf("http://example.org/ValueSet/ExampleVS").evaluate(
+        collection,
+        {"%fhirRelease": "R4", "%terminologyService": terminology_service},
+    )
+    assert result[0].value == True
+
+
+def test_memberof_returns_true_for_valid_codeableconcept(terminology_service):
+    collection = [
+        FHIRPathCollectionItem(
+            value=R4_CodeableConcept(coding=[R4_Coding(code="valid-code")])
+        )
+    ]
+    result = MemberOf("http://example.org/ValueSet/ExampleVS").evaluate(
+        collection,
+        {"%fhirRelease": "R4", "%terminologyService": terminology_service},
+    )
+    assert result[0].value == True
+
+
+def test_memberof_returns_empty_for_unresolvable_valueset(terminology_service):
+    collection = [FHIRPathCollectionItem(value="valid-code")]
+    with pytest.warns(
+        FhirPathWarning, match="Error validating code against valueset in memberOf()"
+    ):
+        result = MemberOf("http://example.org/ValueSet/Unknown").evaluate(
+            collection,
+            {"%fhirRelease": "R4", "%terminologyService": terminology_service},
+        )
+    assert result == []
+
+
+def test_memberof_raises_error_when_fhir_release_not_in_environment(
+    terminology_service,
+):
+    collection = [FHIRPathCollectionItem(value="example-code")]
+    with pytest.raises(FhirPathException, match="required for evaluating memberOf"):
+        MemberOf("http://example.org/ValueSet/ExampleVS").evaluate(
+            collection, {"%terminologyService": terminology_service}
+        )


### PR DESCRIPTION
**PR Title**
Implemented FHIRPath terminology service support and additional function handling

### Added
- Added a pluggable terminology service configuration and wired it into global config handling. Closes #306
- Implemented the FHIRPath `memberOf()`, `subsumes()`, and `subsumedBy()` functions delegated to the plugged terminology service. Fixes #363
- Implemented the `conformsTo` FHIRPath function for core resources (profiles currently not supported).  Fixes #363

### Changed
- Updated the FHIRPath `slice()` function to always return an empty collection rather than raising a `NotImplementedError` (as noted in the official specification). Fixes #363