### PR TITLE
Raises exceptions in `model_validate` and `model_validate_json` to avoid silently ignoring Pydantic parameters

### DIFF
--- a/fhircraft/fhir/resources/base/models.py
+++ b/fhircraft/fhir/resources/base/models.py
@@ -362,25 +362,13 @@ class FHIRBaseModel(
         by_alias: bool | None = None,
         by_name: bool | None = None,
     ) -> Self:
-        """Validate *obj* and return a model instance."""
+        """Validate `obj` and return a model instance."""
         if by_alias is not None:
-            warnings.warn(
-                "FHIRBaseModel.model_validate does not support by_alias. Ignoring.",
-                UserWarning,
-                stacklevel=2,
-            )
+            raise TypeError("FHIRBaseModel.model_validate does not support user-provided `by_alias`.")
         if extra is not None:
-            warnings.warn(
-                "FHIRBaseModel.model_validate does not support extra. Ignoring.",
-                UserWarning,
-                stacklevel=2,
-            )
+            raise TypeError("FHIRBaseModel.model_validate does not support user-provided `extra`.")
         if by_name is not None:
-            warnings.warn(
-                "FHIRBaseModel.model_validate does not support by_name. Ignoring.",
-                UserWarning,
-                stacklevel=2,
-            )
+            raise TypeError("FHIRBaseModel.model_validate does not support user-provided `by_name`.")
         return super().model_validate(
             obj, strict=strict, from_attributes=from_attributes, context=context
         )
@@ -398,23 +386,11 @@ class FHIRBaseModel(
     ) -> Self:
         """Deserialize *json_data* and return a validated model instance."""
         if by_alias is not None:
-            warnings.warn(
-                "FHIRBaseModel.model_validate_json does not support by_alias. Ignoring.",
-                UserWarning,
-                stacklevel=2,
-            )
+            raise TypeError("FHIRBaseModel.model_validate_json does not support user-provided `by_alias`.")
         if extra is not None:
-            warnings.warn(
-                "FHIRBaseModel.model_validate_json does not support extra. Ignoring.",
-                UserWarning,
-                stacklevel=2,
-            )
+            raise TypeError("FHIRBaseModel.model_validate_json does not support user-provided `extra`.")
         if by_name is not None:
-            warnings.warn(
-                "FHIRBaseModel.model_validate_json does not support by_name. Ignoring.",
-                UserWarning,
-                stacklevel=2,
-            )
+            raise TypeError("FHIRBaseModel.model_validate_json does not support user-provided `by_name`.")
         return super().model_validate_json(json_data, strict=strict, context=context)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
This pull request strengthens error handling in the `FHIRBaseModel` validation methods by replacing warnings with exceptions for unsupported keyword arguments. Now, if a user provides the `by_alias`, `extra`, or `by_name` arguments to `model_validate` or `model_validate_json`, a `TypeError` will be raised instead of a warning being issued.

### Changed 

* Updated the `FHIRBaseModel` methods`model_validate` and `model_validate_json` to raise a `TypeError` if `by_alias`, `extra`, or `by_name` are provided, instead of issuing warnings. Fixes #385
