### PR TITLE
Enable mkdocstrings plugin with configurations

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -445,32 +445,32 @@ custom_checkbox = true
 [project.plugins.markdown-exec]
 
 
-# [project.plugins.mkdocstrings]
-# custom_templates = "docs/.overrides"
+[project.plugins.mkdocstrings]
+custom_templates = "docs/.overrides"
 
-# [project.plugins.mkdocstrings.handlers.python]
-# inventories = [
-#   "https://docs.python.org/3/objects.inv",
-#   "https://docs.pydantic.dev/latest/objects.inv",
-#   "https://typing-extensions.readthedocs.io/en/latest/objects.inv"
-# ]
-# paths = ["fhircraft"]
+[project.plugins.mkdocstrings.handlers.python]
+inventories = [
+  "https://docs.python.org/3/objects.inv",
+  "https://docs.pydantic.dev/latest/objects.inv",
+  "https://typing-extensions.readthedocs.io/en/latest/objects.inv"
+]
+paths = ["fhircraft"]
 
-# [project.plugins.mkdocstrings.handlers.python.options]
-# docstring_style = "google"
-# inherited_members = false
-# show_source = false
-# members_order = "source"
-# separate_signature = true
-# filters = ["!^_"]
-# docstring_options.ignore_init_summary = true
-# merge_init_into_class = true
-# show_root_heading = true
-# show_root_full_path = false
-# show_signature_annotations = true
-# summary = true
-# signature_crossrefs = true
-# extensions = [
-#   { "griffe_fieldz" = { "include_inherited" = true } }
-# ]
+[project.plugins.mkdocstrings.handlers.python.options]
+docstring_style = "google"
+inherited_members = false
+show_source = false
+members_order = "source"
+separate_signature = true
+filters = ["!^_"]
+docstring_options.ignore_init_summary = true
+merge_init_into_class = true
+show_root_heading = true
+show_root_full_path = false
+show_signature_annotations = true
+summary = true
+signature_crossrefs = true
+extensions = [
+  { "griffe_fieldz" = { "include_inherited" = true } }
+]
 


### PR DESCRIPTION
This pull request enables and configures the `mkdocstrings` plugin for the project documentation in `zensical.toml`. The configuration was previously erroneously commented out and is now active.

### Fixed
*  Uncommented the `[project.plugins.mkdocstrings]` section in `zensical.toml`.